### PR TITLE
feat: migrate CLI framework from Commander.js to citty

### DIFF
--- a/.changeset/seven-words-divide.md
+++ b/.changeset/seven-words-divide.md
@@ -1,0 +1,11 @@
+---
+"adamantite": patch
+---
+
+Migrate CLI framework from Commander.js to citty for improved developer experience. This change brings better type safety through citty's TypeScript-first design, improved ergonomics as part of the UnJS ecosystem, and a more declarative command definition API.
+
+Key improvements:
+- **Better type safety**: Commands are now defined using `defineCommand()` with fully typed argument definitions
+- **Declarative API**: Command metadata, arguments, and handlers are defined in a single, clear structure rather than chained method calls
+- **Improved DX**: Arguments are automatically parsed and typed, with built-in support for positional arguments, boolean flags, and command metadata
+- **UnJS ecosystem**: citty is part of the UnJS ecosystem, providing better compatibility with other modern JavaScript tooling and conventions

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,8 +51,8 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,26 +39,25 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,16 @@ This project uses changesets for version management:
 
 ### CLI Structure (`src/`)
 
-- **`index.ts`** - Main CLI entry point using Commander.js
+- **`index.ts`** - Main CLI entry point using citty
 - **`commands/`** - Command implementations:
-  - `fix.ts` - Runs Biome formatter and fixes issues via npx
-  - `check.ts` - Runs Biome linter to check for issues via npx
-- **`utils.ts`** - Shared utilities (process execution, package info)
+  - `fix.ts` - Runs Biome formatter and fixes issues
+  - `check.ts` - Runs Biome linter to check for issues
+  - `ci.ts` - Runs Adamantite in CI environments
+  - `init.ts` - Initializes Adamantite configuration
+  - `monorepo.ts` - Runs monorepo-specific checks
+  - `update.ts` - Updates Adamantite configuration
+- **`utils.ts`** - Shared utilities (package manager detection, error handling)
+- **`version.ts`** - Package version detection
 
 ### Build Process
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test"
 import Bun, { spawn } from "bun"
 import { join } from "node:path"
 
+const LOG_PREFIX_REGEX = /^\[log\]\s*/
+
 describe("CLI", () => {
   describe("version", () => {
     test("displays correct version with --version flag", async () => {
@@ -10,6 +12,7 @@ describe("CLI", () => {
       const proc = spawn(["bun", cliPath, "--version"], {
         stdout: "pipe",
         stderr: "pipe",
+        env: { ...process.env, NODE_ENV: undefined },
       })
 
       const output = await new Response(proc.stdout).text()
@@ -17,7 +20,9 @@ describe("CLI", () => {
 
       // Read package.json to get expected version
       const packageJson = await Bun.file("package.json").json()
-      expect(output.trim()).toBe(packageJson.version)
+      // Strip citty's [log] prefix if present (added by consola in CI environments)
+      const version = output.trim().replace(LOG_PREFIX_REGEX, "")
+      expect(version).toBe(packageJson.version)
 
       expect(proc.exitCode).toBe(0)
     })

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,7 @@
       "name": "celestine",
       "dependencies": {
         "@clack/prompts": "0.11.0",
-        "@commander-js/extra-typings": "^14.0.0",
-        "commander": "14.0.1",
+        "citty": "0.1.6",
         "defu": "6.1.4",
         "jsonc-parser": "3.3.1",
         "nypm": "0.6.2",
@@ -93,8 +92,6 @@
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
-
-    "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
 
     "@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 
@@ -195,8 +192,6 @@
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
-
-    "commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
 
     "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
 

--- a/commander.d.ts
+++ b/commander.d.ts
@@ -1,3 +1,0 @@
-declare module "commander" {
-  export * from "@commander-js/extra-typings"
-}

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "dev": "tsdown --watch",
     "check": "biome check",
+    "dev": "tsdown --watch",
     "fix": "biome check --write",
     "release": "changeset publish",
     "test": "bun test",
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@clack/prompts": "0.11.0",
-    "@commander-js/extra-typings": "^14.0.0",
-    "commander": "14.0.1",
+    "citty": "0.1.6",
     "defu": "6.1.4",
     "jsonc-parser": "3.3.1",
     "nypm": "0.6.2"

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,28 +1,48 @@
 import { execSync } from "node:child_process"
+import { defineCommand } from "citty"
 import { dlxCommand } from "nypm"
 import { getPackageManagerName, handleCommandError } from "../utils"
 
-export default async function check(
-  files: string[],
-  { summary }: { summary?: boolean }
-) {
-  try {
-    const packageManager = await getPackageManagerName()
+export default defineCommand({
+  meta: {
+    name: "check",
+    description: "Run Biome linter and check files for issues",
+  },
+  args: {
+    files: {
+      description: "Specific files to lint (optional)",
+      type: "positional",
+      required: false,
+    },
+    summary: {
+      description: "Show summary of lint results",
+      type: "boolean",
+    },
+  },
+  run: async ({ args }) => {
+    try {
+      const packageManager = await getPackageManagerName()
 
-    const args = ["check"]
+      const biomeArgs = ["check"]
 
-    if (summary) {
-      args.push("--reporter", "summary")
+      if (args.summary) {
+        biomeArgs.push("--reporter", "summary")
+      }
+
+      const files = args._
+
+      if (files.length > 0) {
+        biomeArgs.push(...files)
+      }
+
+      execSync(
+        dlxCommand(packageManager, "@biomejs/biome", { args: biomeArgs }),
+        {
+          stdio: "inherit",
+        }
+      )
+    } catch (error) {
+      handleCommandError(error)
     }
-
-    if (files.length > 0) {
-      args.push(...files)
-    }
-
-    execSync(dlxCommand(packageManager, "@biomejs/biome", { args }), {
-      stdio: "inherit",
-    })
-  } catch (error) {
-    handleCommandError(error)
-  }
-}
+  },
+})

--- a/src/commands/ci.ts
+++ b/src/commands/ci.ts
@@ -1,31 +1,43 @@
 import { execSync } from "node:child_process"
+import { defineCommand } from "citty"
 import { dlxCommand } from "nypm"
 import { getPackageManagerName, handleCommandError } from "../utils"
 
-export default async function ci({
-  github,
-  monorepo,
-}: {
-  github?: boolean
-  monorepo?: boolean
-}) {
-  try {
-    const packageManager = await getPackageManagerName()
-
-    const tools = [
-      {
-        package: "@biomejs/biome",
-        args: ["ci", ...(github ? ["--reporter", "github"] : [])],
-      },
-      ...(monorepo ? [{ package: "sherif", args: [] }] : []),
-    ]
-
-    for (const tool of tools) {
-      execSync(dlxCommand(packageManager, tool.package, { args: tool.args }), {
-        stdio: "inherit",
-      })
+export default defineCommand({
+  meta: {
+    name: "ci",
+    description: "Run Adamantite in a CI environment",
+  },
+  args: {
+    monorepo: {
+      description: "Run additional monorepo-specific checks",
+      type: "boolean",
+    },
+    github: {
+      description: "Use GitHub reporter",
+      type: "boolean",
+    },
+  },
+  run: async ({ args }) => {
+    try {
+      const packageManager = await getPackageManagerName()
+      const tools = [
+        {
+          package: "@biomejs/biome",
+          args: ["ci", ...(args.github ? ["--reporter", "github"] : [])],
+        },
+        ...(args.monorepo ? [{ package: "sherif", args: [] }] : []),
+      ]
+      for (const tool of tools) {
+        execSync(
+          dlxCommand(packageManager, tool.package, { args: tool.args }),
+          {
+            stdio: "inherit",
+          }
+        )
+      }
+    } catch (error) {
+      handleCommandError(error)
     }
-  } catch (error) {
-    handleCommandError(error)
-  }
-}
+  },
+})

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -1,28 +1,48 @@
 import { execSync } from "node:child_process"
+import { defineCommand } from "citty"
 import { dlxCommand } from "nypm"
 import { getPackageManagerName, handleCommandError } from "../utils"
 
-export default async function fix(
-  files: string[],
-  options: { unsafe?: boolean }
-) {
-  try {
-    const packageManager = await getPackageManagerName()
+export default defineCommand({
+  meta: {
+    name: "fix",
+    description: "Run Biome linter and fix issues in files",
+  },
+  args: {
+    files: {
+      description: "Specific files to fix (optional)",
+      type: "positional",
+      required: false,
+    },
+    unsafe: {
+      description: "Apply unsafe fixes",
+      type: "boolean",
+    },
+  },
+  run: async ({ args }) => {
+    try {
+      const packageManager = await getPackageManagerName()
 
-    const args = ["check", "--write"]
+      const biomeArgs = ["check", "--write"]
 
-    if (options.unsafe) {
-      args.push("--unsafe")
+      if (args.unsafe) {
+        biomeArgs.push("--unsafe")
+      }
+
+      const files = args._
+
+      if (files.length > 0) {
+        biomeArgs.push(...files)
+      }
+
+      execSync(
+        dlxCommand(packageManager, "@biomejs/biome", { args: biomeArgs }),
+        {
+          stdio: "inherit",
+        }
+      )
+    } catch (error) {
+      handleCommandError(error)
     }
-
-    if (files.length > 0) {
-      args.push(...files)
-    }
-
-    execSync(dlxCommand(packageManager, "@biomejs/biome", { args }), {
-      stdio: "inherit",
-    })
-  } catch (error) {
-    handleCommandError(error)
-  }
-}
+  },
+})

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import {
   outro,
   spinner,
 } from "@clack/prompts"
+import { defineCommand } from "citty"
 import { addDevDependency } from "nypm"
 import {
   checkIfExists,
@@ -197,56 +198,62 @@ async function installDependencies(options?: { monorepo?: boolean }) {
   }
 }
 
-export default async function init() {
-  intro(getTitle())
+export default defineCommand({
+  meta: {
+    name: "init",
+    description: "Initialize Adamantite in the current directory",
+  },
+  run: async () => {
+    intro(getTitle())
 
-  try {
-    const isMonorepo = await checkIsMonorepo()
+    try {
+      const isMonorepo = await checkIsMonorepo()
 
-    // TODO: Select whether to migrate the project to Adamantite (remove ESLint, Prettier, etc.)
+      // TODO: Select whether to migrate the project to Adamantite (remove ESLint, Prettier, etc.)
 
-    const installScripts = await confirmAction(
-      "Do you want to add the `check` and `fix` scripts to your `package.json`?"
-    )
+      const installScripts = await confirmAction(
+        "Do you want to add the `check` and `fix` scripts to your `package.json`?"
+      )
 
-    const installMonorepoScript = isMonorepo
-      ? await confirmAction(
-          "We've detected a monorepo setup in your project. Would you like to install monorepo linting scripts?"
-        )
-      : false
+      const installMonorepoScript = isMonorepo
+        ? await confirmAction(
+            "We've detected a monorepo setup in your project. Would you like to install monorepo linting scripts?"
+          )
+        : false
 
-    const installTypeScript = await confirmAction(
-      "Adamantite provides a TypeScript preset to enforce strict type-safety. Would you like to install it?"
-    )
+      const installTypeScript = await confirmAction(
+        "Adamantite provides a TypeScript preset to enforce strict type-safety. Would you like to install it?"
+      )
 
-    const selectedEditors = await selectEditorConfig()
+      const selectedEditors = await selectEditorConfig()
 
-    // TODO: Select AI assistant rules
+      // TODO: Select AI assistant rules
 
-    await installDependencies({
-      monorepo: installMonorepoScript,
-    })
-
-    await setupBiomeConfig()
-
-    if (installScripts || installMonorepoScript) {
-      await setupScripts({
-        check: installScripts,
-        fix: installScripts,
+      await installDependencies({
         monorepo: installMonorepoScript,
       })
+
+      await setupBiomeConfig()
+
+      if (installScripts || installMonorepoScript) {
+        await setupScripts({
+          check: installScripts,
+          fix: installScripts,
+          monorepo: installMonorepoScript,
+        })
+      }
+
+      if (installTypeScript) {
+        await setupTsConfig()
+      }
+
+      await setupEditorConfig(selectedEditors)
+
+      outro("💠 Adamantite initialized successfully!")
+    } catch (error) {
+      log.error(`${error instanceof Error ? error.message : "Unknown error"}`)
+
+      cancel("Failed to initialize Adamantite")
     }
-
-    if (installTypeScript) {
-      await setupTsConfig()
-    }
-
-    await setupEditorConfig(selectedEditors)
-
-    outro("💠 Adamantite initialized successfully!")
-  } catch (error) {
-    log.error(`${error instanceof Error ? error.message : "Unknown error"}`)
-
-    cancel("Failed to initialize Adamantite")
-  }
-}
+  },
+})

--- a/src/commands/monorepo.ts
+++ b/src/commands/monorepo.ts
@@ -1,15 +1,23 @@
 import { execSync } from "node:child_process"
+import { defineCommand } from "citty"
 import { dlxCommand } from "nypm"
 import { getPackageManagerName, handleCommandError } from "../utils"
 
-export default async function monorepo() {
-  try {
-    const packageManager = await getPackageManagerName()
+export default defineCommand({
+  meta: {
+    name: "monorepo",
+    description:
+      "Lint and automatically fix monorepo-specific issues using Sherif",
+  },
+  run: async () => {
+    try {
+      const packageManager = await getPackageManagerName()
 
-    execSync(dlxCommand(packageManager, "sherif", { args: ["--fix"] }), {
-      stdio: "inherit",
-    })
-  } catch (error) {
-    handleCommandError(error)
-  }
-}
+      execSync(dlxCommand(packageManager, "sherif", { args: ["--fix"] }), {
+        stdio: "inherit",
+      })
+    } catch (error) {
+      handleCommandError(error)
+    }
+  },
+})

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,14 +1,7 @@
-import {
-  cancel,
-  confirm,
-  intro,
-  isCancel,
-  log,
-  outro,
-  spinner,
-} from "@clack/prompts"
+import { confirm, intro, isCancel, log, outro, spinner } from "@clack/prompts"
+import { defineCommand } from "citty"
 import { addDevDependency } from "nypm"
-import { getTitle, readPackageJson } from "../utils"
+import { getTitle, handleCommandError, readPackageJson } from "../utils"
 import { biome, sherif } from "./helpers"
 
 interface DependencyUpdate {
@@ -128,30 +121,35 @@ async function confirmUpdate(updates: DependencyUpdate[]): Promise<boolean> {
   return result
 }
 
-export default async function update() {
-  intro(getTitle())
+export default defineCommand({
+  meta: {
+    name: "update",
+    description: "Update adamantite dependencies to latest compatible versions",
+  },
+  run: async () => {
+    intro(getTitle())
 
-  try {
-    const updates = await detectUpdatesNeeded()
+    try {
+      const updates = await detectUpdatesNeeded()
 
-    if (updates.length === 0) {
-      log.success("All adamantite dependencies are already up to date!")
-      outro("💠 No updates needed")
-      return
+      if (updates.length === 0) {
+        log.success("All adamantite dependencies are already up to date!")
+        outro("💠 No updates needed")
+        return
+      }
+
+      const shouldUpdate = await confirmUpdate(updates)
+
+      if (!shouldUpdate) {
+        outro("💠 Update cancelled")
+        return
+      }
+
+      await updateDependencies(updates)
+
+      outro("💠 Dependencies updated successfully!")
+    } catch (error) {
+      handleCommandError(error)
     }
-
-    const shouldUpdate = await confirmUpdate(updates)
-
-    if (!shouldUpdate) {
-      outro("💠 Update cancelled")
-      return
-    }
-
-    await updateDependencies(updates)
-
-    outro("💠 Dependencies updated successfully!")
-  } catch (error) {
-    log.error(`${error instanceof Error ? error.message : "Unknown error"}`)
-    cancel("Failed to update dependencies")
-  }
-}
+  },
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander"
+import { defineCommand, runMain } from "citty"
 import check from "./commands/check"
 import ci from "./commands/ci"
 import fix from "./commands/fix"
@@ -7,58 +7,21 @@ import monorepo from "./commands/monorepo"
 import update from "./commands/update"
 import version from "./version"
 
-const program = new Command()
+const main = defineCommand({
+  meta: {
+    name: "adamantite",
+    description:
+      "An opinionated set of presets for modern TypeScript applications",
+    version,
+  },
+  subCommands: {
+    check,
+    ci,
+    fix,
+    init,
+    monorepo,
+    update,
+  },
+})
 
-program.version(version)
-
-program
-  .name("adamantite")
-  .description(
-    "An opinionated set of presets for modern TypeScript applications"
-  )
-
-program
-  .command("init")
-  .description("Initialize Adamantite in the current directory")
-  .action(init)
-
-program
-  .command("check")
-  .description("Run Biome linter and check files for issues")
-  .argument("[files...]", "specific files to lint (optional)")
-  .option("--summary", "show summary of lint results")
-  .action(async (files, options) => {
-    await check(files, options)
-  })
-
-program
-  .command("fix")
-  .description("Run Biome linter and fix issues in files")
-  .argument("[files...]", "specific files to fix (optional)")
-  .option("--unsafe", "apply unsafe fixes")
-  .action(async (files, options) => {
-    await fix(files, options)
-  })
-
-program
-  .command("monorepo")
-  .description(
-    "Lint and automatically fix monorepo-specific issues using Sherif"
-  )
-  .action(monorepo)
-
-program
-  .command("ci")
-  .description("Run Adamantitte in a CI environment")
-  .option("--monorepo", "run additional monorepo-specific checks")
-  .option("--github", "use GitHub reporter")
-  .action(async (options) => {
-    await ci(options)
-  })
-
-program
-  .command("update")
-  .description("Update adamantite dependencies to latest compatible versions")
-  .action(update)
-
-program.parse()
+void runMain(main)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { access, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import process from "node:process"
+import { cancel } from "@clack/prompts"
 import { detectPackageManager } from "nypm"
 import type { PackageJson } from "type-fest"
 
@@ -26,7 +27,9 @@ export function handleCommandError(error: unknown) {
     error instanceof Error ? error.message : "An unknown error occurred"
 
   // biome-ignore lint/suspicious/noConsole: We want to log the error to the console
-  console.error("Failed to run Adamantite:", message)
+  console.error(message)
+
+  cancel("Failed to run Adamantite")
 
   process.exit(1)
 }


### PR DESCRIPTION
### TL;DR

Migrated the CLI framework from Commander.js to citty for improved type safety and developer experience.

### What changed?

- Replaced Commander.js with citty as the CLI framework
- Refactored all command modules to use citty's `defineCommand()` API
- Removed Commander.js related dependencies and type definitions
- Updated command structure to use citty's declarative approach
- Added a changeset documenting the migration and its benefits

### How to test?

1. Run `bun install` to update dependencies
2. Test each CLI command to ensure they work as expected:
   ```
   bun run dev
   ./bin/adamantite.js init
   ./bin/adamantite.js check
   ./bin/adamantite.js fix
   ./bin/adamantite.js ci
   ./bin/adamantite.js monorepo
   ./bin/adamantite.js update
   ```
3. Verify that all commands accept the same arguments and options as before

### Why make this change?

The migration to citty provides several key improvements:

- **Better type safety**: Commands are now defined with fully typed argument definitions
- **Declarative API**: Command metadata, arguments, and handlers are defined in a single, clear structure
- **Improved DX**: Arguments are automatically parsed and typed with built-in support for various argument types
- **UnJS ecosystem**: citty integrates better with other modern JavaScript tooling and conventions

This change maintains all existing functionality while making the codebase more maintainable and providing a better foundation for future development.