### PR TITLE
refactor: better organization for initialization

### DIFF
--- a/.changeset/salty-moose-write.md
+++ b/.changeset/salty-moose-write.md
@@ -1,0 +1,9 @@
+---
+"adamantite": minor
+---
+
+Improve `init` and `monorepo` commands with better UX
+
+The `init` command now provides clearer interactive prompts using @clack/prompts, detects monorepo configurations automatically, and offers granular control over which scripts to install. Users can choose individual scripts (check, fix, check:monorepo, fix:monorepo) instead of all-or-nothing installation.
+
+The `monorepo` command now requires the `--fix` flag to auto-fix issues. Running without the flag only checks for issues, making the behavior consistent with the `check` command and preventing unintended modifications.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ This project uses changesets for version management:
   - `check.ts` - Runs Biome linter to check for issues
   - `ci.ts` - Runs Adamantite in CI environments
   - `init.ts` - Initializes Adamantite configuration
-  - `monorepo.ts` - Runs monorepo-specific checks
+  - `monorepo.ts` - Runs monorepo-specific checks (use `--fix` to auto-fix issues)
   - `update.ts` - Updates Adamantite configuration
 - **`utils.ts`** - Shared utilities (package manager detection, error handling)
 - **`version.ts`** - Package version detection

--- a/README.md
+++ b/README.md
@@ -129,8 +129,11 @@ adamantite ci --monorepo
 Special tooling for monorepo projects using [Sherif](https://github.com/QuiiBz/sherif):
 
 ```shell
-# Lint and fix monorepo-specific issues
+# Check for monorepo-specific issues
 adamantite monorepo
+
+# Fix monorepo-specific issues
+adamantite monorepo --fix
 ```
 
 Automatically detects and fixes:

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import Bun, { spawn } from "bun"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const cliPath = join(import.meta.dir, "..", "src", "index.ts")
+
+describe("commands", () => {
+  let tempDir: string
+  let originalCwd: string
+
+  beforeEach(async () => {
+    // Save original directory
+    originalCwd = process.cwd()
+
+    // Create temp directory
+    tempDir = mkdtempSync(join(tmpdir(), "adamantite-commands-test-"))
+
+    // Change to temp directory
+    process.chdir(tempDir)
+
+    // Set up initial package.json
+    await Bun.write(
+      "package.json",
+      JSON.stringify(
+        {
+          name: "test-project",
+          version: "1.0.0",
+          devDependencies: {},
+        },
+        null,
+        2
+      )
+    )
+  })
+
+  afterEach(() => {
+    // Restore original directory
+    process.chdir(originalCwd)
+
+    // Clean up temp directory
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors in tests
+    }
+  })
+
+  describe("check", () => {
+    test("should fail gracefully when no package manager detected", async () => {
+      // No lockfile exists
+      const proc = spawn(["bun", cliPath, "check"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      await proc.exited
+
+      expect(proc.exitCode).toBe(1)
+      // Error message might be in stdout (from @clack/prompts) or stderr
+      const output = stdout + stderr
+      expect(output.length).toBeGreaterThan(0)
+    })
+
+    test("should execute successfully with valid lockfile", async () => {
+      // Create bun.lock to simulate package manager
+      await Bun.write("bun.lock", "")
+
+      const proc = spawn(["bun", cliPath, "check"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      await proc.exited
+
+      // Exit code might be non-zero if biome is not installed or finds issues,
+      // but should not exit with code 1 due to package manager error
+      // We just verify it doesn't crash immediately
+      expect(proc.exitCode).toBeDefined()
+    })
+  })
+
+  describe("fix", () => {
+    test("should fail gracefully when no package manager detected", async () => {
+      // No lockfile exists
+      const proc = spawn(["bun", cliPath, "fix"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      await proc.exited
+
+      expect(proc.exitCode).toBe(1)
+      // Error message might be in stdout (from @clack/prompts) or stderr
+      const output = stdout + stderr
+      expect(output.length).toBeGreaterThan(0)
+    })
+
+    test("should execute successfully with valid lockfile", async () => {
+      // Create bun.lock to simulate package manager
+      await Bun.write("bun.lock", "")
+
+      const proc = spawn(["bun", cliPath, "fix"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      await proc.exited
+
+      // Exit code might be non-zero if biome is not installed or finds issues,
+      // but should not exit with code 1 due to package manager error
+      expect(proc.exitCode).toBeDefined()
+    })
+  })
+
+  describe("ci", () => {
+    test("should fail gracefully when no package manager detected", async () => {
+      // No lockfile exists
+      const proc = spawn(["bun", cliPath, "ci"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      await proc.exited
+
+      expect(proc.exitCode).toBe(1)
+      // Error message might be in stdout (from @clack/prompts) or stderr
+      const output = stdout + stderr
+      expect(output.length).toBeGreaterThan(0)
+    })
+
+    test("should execute successfully with valid lockfile", async () => {
+      // Create bun.lock to simulate package manager
+      await Bun.write("bun.lock", "")
+
+      const proc = spawn(["bun", cliPath, "ci"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      await proc.exited
+
+      // Exit code might be non-zero if biome is not installed or finds issues,
+      // but should not exit with code 1 due to package manager error
+      expect(proc.exitCode).toBeDefined()
+    })
+  })
+
+  describe("monorepo", () => {
+    test("should fail gracefully when no package manager detected", async () => {
+      // No lockfile exists
+      const proc = spawn(["bun", cliPath, "monorepo"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      await proc.exited
+
+      expect(proc.exitCode).toBe(1)
+      // Error message might be in stdout (from @clack/prompts) or stderr
+      const output = stdout + stderr
+      expect(output.length).toBeGreaterThan(0)
+    })
+
+    test("should execute successfully with valid lockfile", async () => {
+      // Create bun.lock to simulate package manager
+      await Bun.write("bun.lock", "")
+
+      const proc = spawn(["bun", cliPath, "monorepo"], {
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: tempDir,
+        env: { ...process.env, NODE_ENV: undefined },
+      })
+
+      await proc.exited
+
+      // Exit code might be non-zero if sherif is not installed or finds issues,
+      // but should not exit with code 1 due to package manager error
+      expect(proc.exitCode).toBeDefined()
+    })
+  })
+})

--- a/__tests__/helpers.integration.test.ts
+++ b/__tests__/helpers.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import Bun from "bun"
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { vscode } from "#helpers/editors/vscode.ts"
@@ -189,6 +189,76 @@ describe("helpers integration", () => {
       expect(config.extends).toEqual(["adamantite"])
       expect(config.rules).toEqual({ recommended: true })
     })
+
+    test("should handle create() failure when writing biome.jsonc fails", async () => {
+      // Create a read-only directory to prevent writing
+      mkdirSync("readonly-dir", { recursive: true })
+      chmodSync("readonly-dir", 0o555) // Read-only directory
+      process.chdir("readonly-dir")
+
+      const createResult = await biome.create()
+      // This might succeed on some systems, but if it fails, it should have the right error
+      if (createResult.isErr()) {
+        expect(createResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
+
+      // Restore directory
+      process.chdir(tempDir)
+    })
+
+    test("should return FILE_NOT_FOUND when update() is called without biome config", async () => {
+      // Ensure no biome config exists
+      const exists = await biome.exists()
+      expect(exists.path).toBe(null)
+
+      const updateResult = await biome.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FILE_NOT_FOUND")
+      }
+    })
+
+    test("should handle update() failure when reading biome config fails", async () => {
+      // Create a directory named biome.jsonc to cause read failure
+      mkdirSync("biome.jsonc", { recursive: true })
+
+      const updateResult = await biome.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_READ_FILE")
+      }
+    })
+
+    test("should return INVALID_BIOME_CONFIG for empty config", async () => {
+      // Create empty biome.jsonc
+      await Bun.write("biome.jsonc", "{}")
+
+      const updateResult = await biome.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("INVALID_BIOME_CONFIG")
+      }
+    })
+
+    test("should handle update() failure when writing biome config fails", async () => {
+      // Create valid biome.jsonc
+      await Bun.write(
+        "biome.jsonc",
+        JSON.stringify({
+          rules: {
+            recommended: true,
+          },
+        })
+      )
+      // Make it read-only to prevent writing
+      chmodSync("biome.jsonc", 0o444)
+
+      const updateResult = await biome.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
+    })
   })
 
   describe("tsconfig helper", () => {
@@ -271,6 +341,51 @@ describe("helpers integration", () => {
       // Our extends should override existing extends
       expect(config.extends).toBe("adamantite/tsconfig")
       expect(config.compilerOptions).toEqual({ target: "ES2020" })
+    })
+
+    test("should handle create() failure when writing tsconfig.json fails", async () => {
+      // Create a read-only directory to prevent writing
+      mkdirSync("readonly-dir", { recursive: true })
+      chmodSync("readonly-dir", 0o555) // Read-only directory
+      process.chdir("readonly-dir")
+
+      const createResult = await tsconfig.create()
+      // This might succeed on some systems, but if it fails, it should have the right error
+      if (createResult.isErr()) {
+        expect(createResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
+
+      // Restore directory
+      process.chdir(tempDir)
+    })
+
+    test("should handle update() failure when reading tsconfig.json fails", async () => {
+      // Try to update a non-existent file
+      const updateResult = await tsconfig.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_READ_FILE")
+      }
+    })
+
+    test("should handle update() failure when writing tsconfig.json fails", async () => {
+      // Create valid tsconfig.json
+      await Bun.write(
+        "tsconfig.json",
+        JSON.stringify({
+          compilerOptions: {
+            target: "ES2020",
+          },
+        })
+      )
+      // Make it read-only to prevent writing
+      chmodSync("tsconfig.json", 0o444)
+
+      const updateResult = await tsconfig.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
     })
   })
 
@@ -366,6 +481,54 @@ describe("helpers integration", () => {
           "[javascript][typescript][javascriptreact][typescriptreact][json][jsonc][css][graphql]"
         ]["editor.defaultFormatter"]
       ).toBe("biomejs.biome")
+    })
+
+    test("should handle create() failure when directory creation fails", async () => {
+      // Create a file with the name .vscode to prevent directory creation
+      writeFileSync(".vscode", "not a directory")
+
+      const createResult = await vscode.create()
+      expect(createResult.isErr()).toBe(true)
+      if (createResult.isErr()) {
+        expect(createResult.error.tag).toBe("FAILED_TO_CREATE_DIRECTORY")
+      }
+    })
+
+    test("should handle create() failure when writing settings.json fails", async () => {
+      // Create .vscode directory
+      mkdirSync(".vscode", { recursive: true })
+      // Create a read-only file to prevent writing
+      writeFileSync(".vscode/settings.json", "{}")
+      chmodSync(".vscode/settings.json", 0o444) // Read-only
+
+      const createResult = await vscode.create()
+      // This might succeed on some systems, but if it fails, it should have the right error
+      if (createResult.isErr()) {
+        expect(createResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
+    })
+
+    test("should handle update() failure when reading settings.json fails", async () => {
+      // Try to update a non-existent file
+      const updateResult = await vscode.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_READ_FILE")
+      }
+    })
+
+    test("should handle update() failure when writing settings.json fails", async () => {
+      // Create .vscode directory and settings.json
+      mkdirSync(".vscode", { recursive: true })
+      await Bun.write(".vscode/settings.json", JSON.stringify({ "editor.fontSize": 14 }))
+      // Make the file read-only to prevent writing
+      chmodSync(".vscode/settings.json", 0o444)
+
+      const updateResult = await vscode.update()
+      expect(updateResult.isErr()).toBe(true)
+      if (updateResult.isErr()) {
+        expect(updateResult.error.tag).toBe("FAILED_TO_WRITE_FILE")
+      }
     })
   })
 })

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -4,7 +4,17 @@ import { mkdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { PackageJson } from "type-fest"
-import { checkIfExists, getTitle, mergeConfig, parseJson, readPackageJson } from "#utils.ts"
+import {
+  checkIfExists,
+  checkIsMonorepo,
+  defineCommand,
+  getPackageManagerName,
+  mergeConfig,
+  parseJson,
+  printTitle,
+  readPackageJson,
+  runCommand,
+} from "#utils.ts"
 
 // Mock spawnSync for testing
 mock.module("node:child_process", () => ({
@@ -176,63 +186,237 @@ describe("utils", () => {
       // defu merges left-to-right, so base values win
       expect(result._unsafeUnwrap()).toEqual({ a: { x: 1, y: 2, z: 5 }, b: 3 })
     })
+
+    test("should handle mergeConfig error when defu throws", () => {
+      // Use a Proxy that throws when any property is accessed
+      // This simulates defu encountering an error during merge
+      const throwingBase = new Proxy(
+        {},
+        {
+          get() {
+            throw new Error("Simulated defu error")
+          },
+          ownKeys() {
+            throw new Error("Simulated defu error")
+          },
+        }
+      )
+
+      const result = mergeConfig(throwingBase, { b: 2 })
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.tag).toBe("FAILED_TO_MERGE_CONFIG")
+      }
+    })
   })
 
-  describe("getTitle", () => {
-    let originalColumns: number | undefined
+  describe("defineCommand", () => {
+    test("should return the input command module unchanged", () => {
+      const mockCommand = {
+        command: "test",
+        describe: "Test command",
+        handler: () => {
+          // Empty handler for testing
+        },
+      }
 
-    beforeEach(() => {
-      originalColumns = process.stdout.columns
+      const result = defineCommand(mockCommand)
+      expect(result).toBe(mockCommand)
+      expect(result).toEqual(mockCommand)
+    })
+  })
+
+  describe("runCommand", () => {
+    test("should successfully run a valid command", () => {
+      const result = runCommand("echo test")
+
+      expect(result.isOk()).toBe(true)
     })
 
-    afterEach(() => {
-      if (originalColumns !== undefined) {
-        process.stdout.columns = originalColumns
-      } else {
-        ;(process.stdout as { columns?: number }).columns = undefined
+    test("should return the command output", () => {
+      const result = runCommand("echo hello world")
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        const output = result.value.toString()
+        expect(output).toContain("hello world")
       }
     })
 
-    test("should return large ASCII art for wide terminals", () => {
-      process.stdout.columns = 150
-      const result = getTitle()
+    test("should return error with FAILED_TO_RUN_COMMAND tag for invalid command", () => {
+      const result = runCommand("nonexistent-command-12345")
 
-      expect(result).toContain("█████")
-      expect(result).not.toContain(
-        "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
-      )
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.tag).toBe("FAILED_TO_RUN_COMMAND")
+      }
+    })
+  })
+
+  describe("getPackageManagerName", () => {
+    test("should detect bun when bun.lock exists", async () => {
+      await Bun.write(join(testDir, "package.json"), JSON.stringify({ name: "test" }))
+      await Bun.write(join(testDir, "bun.lock"), "")
+
+      const result = await getPackageManagerName()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe("bun")
+      }
     })
 
-    test("should return simple box for narrow terminals", () => {
-      process.stdout.columns = 80
-      const result = getTitle()
+    test("should detect npm when package-lock.json exists", async () => {
+      await Bun.write(join(testDir, "package.json"), JSON.stringify({ name: "test" }))
+      await Bun.write(join(testDir, "package-lock.json"), "{}")
 
-      expect(result).toContain(
-        "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
-      )
-      expect(result).toContain("ADAMANTITE")
-      expect(result).not.toContain("█████")
+      const result = await getPackageManagerName()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe("npm")
+      }
     })
 
-    test("should return simple box when columns is undefined", () => {
-      ;(process.stdout as { columns?: number }).columns = undefined
-      const result = getTitle()
+    test("should detect pnpm when pnpm-lock.yaml exists", async () => {
+      await Bun.write(join(testDir, "package.json"), JSON.stringify({ name: "test" }))
+      await Bun.write(join(testDir, "pnpm-lock.yaml"), "")
 
-      expect(result).toContain(
-        "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
-      )
-      expect(result).toContain("ADAMANTITE")
+      const result = await getPackageManagerName()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe("pnpm")
+      }
     })
 
-    test("should return large ASCII art for exactly 120 columns", () => {
-      process.stdout.columns = 120
-      const result = getTitle()
+    test("should detect yarn when yarn.lock exists", async () => {
+      await Bun.write(join(testDir, "package.json"), JSON.stringify({ name: "test" }))
+      await Bun.write(join(testDir, "yarn.lock"), "")
 
-      // At exactly 120, should use large art (>= 120)
-      expect(result).toContain("█████")
-      expect(result).not.toContain(
-        "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
-      )
+      const result = await getPackageManagerName()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe("yarn")
+      }
+    })
+
+    test("should return error with NO_PACKAGE_MANAGER tag when no lockfile exists", async () => {
+      await Bun.write(join(testDir, "package.json"), JSON.stringify({ name: "test" }))
+
+      const result = await getPackageManagerName()
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.tag).toBe("NO_PACKAGE_MANAGER")
+      }
+    })
+  })
+
+  describe("checkIsMonorepo", () => {
+    test("should return true when pnpm-workspace.yaml exists", async () => {
+      await Bun.write(join(testDir, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'")
+
+      const result = await checkIsMonorepo()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe(true)
+      }
+    })
+
+    test("should return true when package.json has workspaces field", async () => {
+      const packageJson: PackageJson = {
+        name: "test-package",
+        workspaces: ["packages/*"],
+      }
+
+      await Bun.write(join(testDir, "package.json"), JSON.stringify(packageJson, null, 2))
+
+      const result = await checkIsMonorepo()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe(true)
+      }
+    })
+
+    test("should return false when neither condition is met", async () => {
+      const packageJson: PackageJson = {
+        name: "test-package",
+        version: "1.0.0",
+      }
+
+      await Bun.write(join(testDir, "package.json"), JSON.stringify(packageJson, null, 2))
+
+      const result = await checkIsMonorepo()
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toBe(false)
+      }
+    })
+
+    test("should return error when package.json does not exist and no pnpm-workspace.yaml", async () => {
+      const result = await checkIsMonorepo()
+      expect(result.isErr()).toBe(true)
+    })
+  })
+
+  describe("printTitle", () => {
+    let originalColumns: number | undefined
+    let originalConsoleLog: typeof console.log
+    let callCount: number
+
+    beforeEach(() => {
+      originalColumns = process.stdout.columns
+      // biome-ignore lint/suspicious/noConsole: saving original console.log for restoration
+      originalConsoleLog = console.log
+      callCount = 0
+      const mockLog = mock(() => {
+        callCount++
+      })
+
+      console.log = mockLog as typeof console.log
+    })
+
+    afterEach(() => {
+      Object.defineProperty(process.stdout, "columns", {
+        value: originalColumns,
+        writable: true,
+        configurable: true,
+      })
+
+      console.log = originalConsoleLog
+    })
+
+    test("should print title when terminal is wide enough", () => {
+      Object.defineProperty(process.stdout, "columns", {
+        value: 120,
+        writable: true,
+        configurable: true,
+      })
+
+      printTitle()
+
+      expect(callCount).toBe(1)
+    })
+
+    test("should not print title when terminal is too narrow", () => {
+      Object.defineProperty(process.stdout, "columns", {
+        value: 50,
+        writable: true,
+        configurable: true,
+      })
+
+      printTitle()
+
+      expect(callCount).toBe(0)
+    })
+
+    test("should not print title when process.stdout.columns is undefined", () => {
+      Object.defineProperty(process.stdout, "columns", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      })
+
+      printTitle()
+
+      expect(callCount).toBe(0)
     })
   })
 })

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "celestine",
       "dependencies": {
-        "@clack/prompts": "0.11.0",
+        "@clack/prompts": "1.0.0-alpha.9",
         "defu": "6.1.4",
         "faultier": "^1.1.0",
         "jsonc-parser": "3.3.1",
@@ -96,9 +96,9 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
-    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+    "@clack/core": ["@clack/core@1.0.0-alpha.7", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ=="],
 
-    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+    "@clack/prompts": ["@clack/prompts@1.0.0-alpha.9", "", { "dependencies": { "@clack/core": "1.0.0-alpha.7", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-sKs0UjiHFWvry4SiRfBi5Qnj0C/6AYx8aKkFPZQSuUZXgAram25ZDmhQmP7vj1aFyLpfHWtLQjWvOvcat0TOLg=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg=="],
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
   "license": "MIT",
   "author": "Adel Rodriguez <hello@adelrodriguez.com>",
   "type": "module",
-  "main": "presets/biome.jsonc",
-  "bin": {
-    "adamantite": "bin/adamantite"
-  },
   "imports": {
     "#*": "./src/*"
   },
@@ -33,6 +29,10 @@
     "./biome": "./presets/biome.jsonc",
     "./tsconfig": "./presets/tsconfig.json",
     "./presets/*": "./presets/*"
+  },
+  "main": "presets/biome.jsonc",
+  "bin": {
+    "adamantite": "bin/adamantite"
   },
   "files": [
     "bin",
@@ -47,12 +47,13 @@
     "fix": "bun --bun run src/index.ts fix",
     "release": "changeset publish",
     "test": "bun test",
+    "test:coverage": "bun test --coverage",
     "test:watch": "bun --watch test",
     "typecheck": "tsc --noEmit",
     "version": "changeset version"
   },
   "dependencies": {
-    "@clack/prompts": "0.11.0",
+    "@clack/prompts": "1.0.0-alpha.9",
     "defu": "6.1.4",
     "faultier": "^1.1.0",
     "jsonc-parser": "3.3.1",

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,7 +8,7 @@ import { defineCommand, getPackageManagerName, runCommand } from "#utils.ts"
 
 export default defineCommand({
   command: "check [files..]",
-  describe: "Run Biome linter and check files for issues",
+  describe: "Find issues in code using Biome",
   builder: (yargs) =>
     yargs
       .positional("files", {

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -8,7 +8,7 @@ import { defineCommand, getPackageManagerName, runCommand } from "#utils.ts"
 
 export default defineCommand({
   command: "fix [files..]",
-  describe: "Run Biome linter and fix issues in files",
+  describe: "Fix issues in code using Biome",
   builder: (yargs) =>
     yargs
       .positional("files", {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import process from "node:process"
-import { cancel, confirm, intro, isCancel, log, multiselect, outro, spinner } from "@clack/prompts"
+import * as p from "@clack/prompts"
 import { Fault } from "faultier"
 import { err, fromPromise, fromSafePromise, ok, safeTry } from "neverthrow"
 import { addDevDependency } from "nypm"
@@ -9,7 +9,150 @@ import { vscode } from "#helpers/editors/vscode.ts"
 import { biome } from "#helpers/packages/biome.ts"
 import { sherif } from "#helpers/packages/sherif.ts"
 import { tsconfig } from "#helpers/tsconfig.ts"
-import { checkIfExists, defineCommand, getTitle, readPackageJson } from "#utils.ts"
+import {
+  checkIsMonorepo,
+  defineCommand,
+  getPackageManagerName,
+  printTitle,
+  readPackageJson,
+} from "#utils.ts"
+
+const installDependencies = (packages: string[]) =>
+  safeTry(async function* () {
+    const s = p.spinner()
+    s.start("Installing dependencies...")
+    const isMonorepo = yield* checkIsMonorepo()
+
+    for (const pkg of packages) {
+      yield* fromPromise(addDevDependency(pkg, { silent: true, workspace: isMonorepo }), (error) =>
+        Fault.wrap(error)
+          .withTag("FAILED_TO_INSTALL_DEPENDENCY")
+          .withMessage(`Failed to install ${pkg}`)
+      )
+    }
+
+    s.stop("Dependencies installed.")
+
+    return ok()
+  })
+
+const setupBiomeConfig = () =>
+  safeTry(async function* () {
+    const spinner = p.spinner()
+    spinner.start("Setting up Biome config...")
+
+    const biomePath = await biome.exists()
+
+    if (biomePath.path) {
+      spinner.message(`Found \`${biomePath.path}\`, updating...`)
+
+      yield* biome.update()
+
+      spinner.stop("Biome config updated successfully.")
+    } else {
+      spinner.message("`.biome.jsonc` or `.biome.json` not found, creating...")
+
+      yield* biome.create()
+
+      spinner.stop("Biome config created successfully.")
+    }
+
+    return ok()
+  })
+
+const addScripts = (scripts: string[]) =>
+  safeTry(async function* () {
+    const cwd = process.cwd()
+    const packageJson = yield* readPackageJson()
+    const spinner = p.spinner()
+    spinner.start("Adding scripts to your `package.json`...")
+
+    if (!packageJson.scripts) {
+      packageJson.scripts = {}
+    }
+
+    for (const script of scripts) {
+      switch (script) {
+        case "check":
+          packageJson.scripts.check = "adamantite check"
+          break
+        case "fix":
+          packageJson.scripts.fix = "adamantite fix"
+          break
+        case "check:monorepo":
+          packageJson.scripts["check:monorepo"] = "adamantite monorepo"
+          break
+        case "fix:monorepo":
+          packageJson.scripts["fix:monorepo"] = "adamantite monorepo --fix"
+          break
+        default:
+          return err(Fault.create("UNKNOWN_SCRIPT").withContext({ script }))
+      }
+    }
+
+    yield* fromPromise(
+      writeFile(join(cwd, "package.json"), JSON.stringify(packageJson, null, 2)),
+      (error) =>
+        Fault.wrap(error)
+          .withTag("FAILED_TO_WRITE_FILE")
+          .withDescription(
+            "Failed to write package.json",
+            "We're unable to update the package.json file."
+          )
+          .withContext({ path: join(cwd, "package.json") })
+    )
+
+    spinner.stop("Scripts added to your `package.json`")
+
+    return ok()
+  })
+
+const setupTypescript = () =>
+  safeTry(async function* () {
+    const spinner = p.spinner()
+    spinner.start("Setting up TypeScript config...")
+
+    if (await tsconfig.exists()) {
+      spinner.message("`tsconfig.json` found, updating...")
+
+      yield* tsconfig.update()
+
+      spinner.stop("`tsconfig.json` updated successfully")
+    } else {
+      spinner.message("`tsconfig.json` not found, creating...")
+
+      yield* tsconfig.create()
+
+      spinner.stop("`tsconfig.json` created successfully")
+    }
+
+    return ok()
+  })
+
+const setupEditors = (editors: string[]) =>
+  safeTry(async function* () {
+    if (editors.includes("vscode")) {
+      const spinner = p.spinner()
+
+      spinner.start("Checking for `.vscode/settings.json`...")
+
+      if (await vscode.exists()) {
+        spinner.message("`.vscode/settings.json` found, updating...")
+        yield* vscode.update()
+        spinner.stop("`.vscode/settings.json` updated with Adamantite preset.")
+      } else {
+        spinner.message("`.vscode/settings.json` not found, creating...")
+        yield* vscode.create()
+        spinner.stop("`.vscode/settings.json` created with Adamantite preset.")
+      }
+    }
+
+    if (editors.includes("zed")) {
+      // TODO: Implement Zed configuration
+    }
+
+    return ok()
+  })
 
 export default defineCommand({
   command: "init",
@@ -17,219 +160,130 @@ export default defineCommand({
   builder: (yargs) => yargs,
   handler: () =>
     safeTry(async function* () {
-      const cwd = process.cwd()
+      const packageManager = yield* getPackageManagerName()
 
-      // Check first if we are in a project with a package.json file
-      let packageJson = yield* readPackageJson()
+      printTitle()
 
-      intro(getTitle())
+      p.intro("💠 adamantite init")
 
-      const hasPnpmWorkspace = await checkIfExists(join(cwd, "pnpm-workspace.yaml"))
+      p.log.info(`Detected package manager: ${packageManager}`)
 
-      const isMonorepo = packageJson.workspaces !== undefined || hasPnpmWorkspace
+      const isMonorepo = yield* checkIsMonorepo()
 
-      const shouldInstallScripts = yield* fromSafePromise(
-        confirm({
-          message: "Do you want to add the `check` and `fix` scripts to your `package.json`?",
+      if (isMonorepo) {
+        p.log.info("We've detected a monorepo setup in your project.")
+      }
+
+      const scripts = yield* fromSafePromise(
+        p.multiselect({
+          message: "Which scripts do you want to add to your `package.json`?",
+          options: [
+            {
+              label: "check - find issues in your code using Biome",
+              value: "check",
+              hint: "recommended",
+            },
+            {
+              label: "fix - fix issues and format your code using Biome",
+              value: "fix",
+              hint: "recommended",
+            },
+
+            {
+              label: "check:monorepo - check for monorepo-specific issues using Sherif",
+              value: "check:monorepo",
+              hint: isMonorepo ? undefined : "available for monorepo projects",
+              disabled: !isMonorepo,
+            },
+            {
+              label: "fix:monorepo - fix monorepo-specific issues using Sherif",
+              value: "fix:monorepo",
+              hint: isMonorepo ? undefined : "available for monorepo projects",
+              disabled: !isMonorepo,
+            },
+          ],
         })
       )
 
-      if (isCancel(shouldInstallScripts)) {
+      if (p.isCancel(scripts)) {
         return err(Fault.create("OPERATION_CANCELLED"))
       }
 
-      let shouldInstallMonorepoScripts = false
-
-      if (isMonorepo) {
-        const shouldInstallMonorepoScriptsResponse = yield* fromSafePromise(
-          confirm({
-            message:
-              "We've detected a monorepo setup in your project. Would you like to install monorepo linting scripts?",
-          })
-        )
-
-        if (isCancel(shouldInstallMonorepoScriptsResponse)) {
-          return err(Fault.create("OPERATION_CANCELLED"))
-        }
-
-        shouldInstallMonorepoScripts = shouldInstallMonorepoScriptsResponse
-      }
-
-      const shouldInstallTypeScriptPreset = yield* fromSafePromise(
-        confirm({
+      const typescriptPreset = yield* fromSafePromise(
+        p.confirm({
           message:
             "Adamantite provides a TypeScript preset to enforce strict type-safety. Would you like to install it?",
         })
       )
 
-      if (isCancel(shouldInstallTypeScriptPreset)) {
+      if (p.isCancel(typescriptPreset)) {
         return err(Fault.create("OPERATION_CANCELLED"))
       }
 
-      const selectedEditors = yield* fromSafePromise(
-        multiselect({
-          message: "Which editors do you want to configure (recommended)?",
+      const editors = yield* fromSafePromise(
+        p.multiselect({
+          message: "Which editors do you want to configure? (optional)",
           options: [
             { label: "VSCode / Cursor / Windsurf", value: "vscode" },
-            { label: "Zed (coming soon)", value: "zed" },
+            { label: "Zed", value: "zed", disabled: true, hint: "coming soon" },
           ],
           required: false,
         })
       )
 
-      if (isCancel(selectedEditors)) {
+      if (p.isCancel(editors)) {
         return err(Fault.create("OPERATION_CANCELLED"))
       }
 
-      // =============================== ADD DEPENDENCIES ===============================
-      const installingDependencies = spinner()
+      const hasBiome = scripts.includes("check") || scripts.includes("fix")
+      const hasSherif = scripts.includes("check:monorepo") || scripts.includes("fix:monorepo")
 
-      installingDependencies.start("Installing dependencies...")
+      const dependencies = ["adamantite"]
 
-      // Install Adamantite first
-      yield* fromPromise(addDevDependency("adamantite"), (error) =>
-        Fault.wrap(error)
-          .withTag("FAILED_TO_INSTALL_DEPENDENCY")
-          .withMessage("Failed to install Adamantite")
-      )
-
-      yield* fromPromise(addDevDependency(`${biome.name}@${biome.version}`), (error) =>
-        Fault.wrap(error)
-          .withTag("FAILED_TO_INSTALL_DEPENDENCY")
-          .withMessage("Failed to install Biome")
-      )
-
-      if (shouldInstallMonorepoScripts) {
-        yield* fromPromise(addDevDependency(`${sherif.name}@${sherif.version}`), (error) =>
-          Fault.wrap(error)
-            .withTag("FAILED_TO_INSTALL_DEPENDENCY")
-            .withMessage("Failed to install Sherif")
-        )
+      if (hasBiome) {
+        dependencies.push(`${biome.name}@${biome.version}`)
       }
 
-      installingDependencies.stop("Dependencies installed successfully")
-
-      // =============================== SETUP BIOME CONFIG ===============================
-      const settingUpBiomeConfig = spinner()
-
-      settingUpBiomeConfig.start("Setting up Biome config...")
-
-      const biomePath = await biome.exists()
-
-      if (biomePath.path) {
-        settingUpBiomeConfig.message("Biome config found, updating...")
-
-        yield* biome.update()
-
-        settingUpBiomeConfig.stop("Biome config updated successfully")
-      } else {
-        settingUpBiomeConfig.message("Biome config not found, creating...")
-
-        yield* biome.create()
-
-        settingUpBiomeConfig.stop("Biome config created successfully")
+      if (hasSherif) {
+        dependencies.push(`${sherif.name}@${sherif.version}`)
       }
 
-      // =============================== ADD SCRIPTS ===============================
-      if (shouldInstallScripts) {
-        const addingScripts = spinner()
-        packageJson = yield* readPackageJson()
-        addingScripts.start("Adding scripts to your `package.json`...")
+      yield* installDependencies(dependencies)
 
-        if (!packageJson.scripts) {
-          packageJson.scripts = {}
-        }
-
-        packageJson.scripts.check = "adamantite check"
-        packageJson.scripts.fix = "adamantite fix"
-
-        if (shouldInstallMonorepoScripts) {
-          packageJson.scripts["lint:monorepo"] = "adamantite monorepo"
-        }
-
-        yield* fromPromise(
-          writeFile(join(cwd, "package.json"), JSON.stringify(packageJson, null, 2)),
-          (error) =>
-            Fault.wrap(error)
-              .withTag("FAILED_TO_WRITE_FILE")
-              .withDescription(
-                "Failed to write package.json",
-                "We're unable to update the package.json file."
-              )
-              .withContext({ path: join(cwd, "package.json") })
-        )
-
-        addingScripts.stop("Scripts added to your `package.json`")
+      if (hasBiome) {
+        yield* setupBiomeConfig()
       }
 
-      // =============================== SETUP TYPESCRIPT CONFIG ===============================
+      yield* addScripts(scripts)
 
-      if (shouldInstallTypeScriptPreset) {
-        const settingUpTypeScriptConfig = spinner()
-        settingUpTypeScriptConfig.start("Setting up TypeScript config...")
-
-        if (await tsconfig.exists()) {
-          settingUpTypeScriptConfig.message("`tsconfig.json` found, updating...")
-
-          yield* tsconfig.update()
-
-          settingUpTypeScriptConfig.stop("`tsconfig.json` updated successfully")
-        } else {
-          settingUpTypeScriptConfig.message("`tsconfig.json` not found, creating...")
-
-          yield* tsconfig.create()
-
-          settingUpTypeScriptConfig.stop("`tsconfig.json` created successfully")
-        }
+      if (typescriptPreset) {
+        yield* setupTypescript()
       }
 
-      // =============================== SETUP EDITOR CONFIG ===============================
-
-      if (selectedEditors.length > 0) {
-        const settingUpEditorConfig = spinner()
-        settingUpEditorConfig.start("Setting up editor config...")
-
-        if (selectedEditors.includes("vscode")) {
-          const settingUpVSCodeConfig = spinner()
-          settingUpVSCodeConfig.start("Setting up VSCode config...")
-
-          if (await vscode.exists()) {
-            settingUpVSCodeConfig.message("VSCode settings found, updating...")
-            yield* vscode.update()
-            settingUpVSCodeConfig.stop("VSCode settings updated with Adamantite preset")
-          } else {
-            settingUpVSCodeConfig.message("VSCode settings not found, creating...")
-            yield* vscode.create()
-            settingUpVSCodeConfig.stop("VSCode settings created with Adamantite preset")
-          }
-        }
-
-        if (selectedEditors.includes("zed")) {
-          log.warning("Zed configuration coming soon...")
-        }
-
-        settingUpEditorConfig.stop("Editor config set up successfully")
-      }
+      yield* setupEditors(editors)
 
       return ok()
     }).match(
       () => {
-        outro("💠 Adamantite initialized successfully!")
+        p.outro("💠 Adamantite initialized successfully!")
         process.exit(0)
       },
       (error) => {
         if (Fault.isFault(error) && error.tag === "OPERATION_CANCELLED") {
-          cancel("You've cancelled the initialization process.")
+          p.cancel("You've cancelled the initialization process.")
           process.exit(0)
         }
 
-        if (Fault.isFault(error)) {
-          log.error(error.flatten())
-        } else {
-          log.error(String(error))
+        if (!Fault.isFault(error)) {
+          // We should never reach this point
+          p.log.error(`An unexpected error occurred: ${String(error)}`)
+          p.cancel("Failed to initialize Adamantite")
+          process.exit(1)
         }
 
-        cancel("Failed to initialize Adamantite")
+        p.log.error(error.flatten())
+
+        p.cancel("Failed to initialize Adamantite")
         process.exit(1)
       }
     ),

--- a/src/commands/monorepo.ts
+++ b/src/commands/monorepo.ts
@@ -8,13 +8,21 @@ import { defineCommand, getPackageManagerName, runCommand } from "#utils.ts"
 
 export default defineCommand({
   command: "monorepo",
-  describe: "Lint and automatically fix monorepo-specific issues using Sherif",
-  builder: (yargs) => yargs,
-  handler: () =>
+  describe: "Find and fix monorepo-specific issues using Sherif",
+  builder: (yargs) =>
+    yargs.option("fix", {
+      type: "boolean",
+      description: "Automatically fix issues",
+    }),
+  handler: (argv) =>
     safeTry(async function* () {
       const packageManager = yield* getPackageManagerName()
 
-      const args = ["--fix"]
+      const args: string[] = []
+
+      if (argv.fix) {
+        args.push("--fix")
+      }
 
       const command = dlxCommand(packageManager, sherif.name, { args })
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -5,7 +5,7 @@ import { err, fromPromise, fromSafePromise, ok, safeTry } from "neverthrow"
 import { addDevDependency } from "nypm"
 import { biome } from "#helpers/packages/biome.ts"
 import { sherif } from "#helpers/packages/sherif.ts"
-import { defineCommand, getTitle, readPackageJson } from "#utils.ts"
+import { defineCommand, printTitle, readPackageJson } from "#utils.ts"
 
 export default defineCommand({
   command: "update",
@@ -13,10 +13,11 @@ export default defineCommand({
   builder: (yargs) => yargs,
   handler: async () =>
     safeTry(async function* () {
-      // Read package.json using yield*
       const packageJson = yield* readPackageJson()
 
-      intro(getTitle())
+      printTitle()
+
+      intro("💠 adamantite update")
 
       // Detect updates needed
       const updates: {
@@ -85,11 +86,11 @@ export default defineCommand({
     }).match(
       (value) => {
         if (value === "no-updates") {
-          outro("💠 No updates needed")
+          outro("✅ No updates needed")
         } else if (value === "cancelled") {
-          outro("💠 Update cancelled")
+          outro("⚠️ Update cancelled")
         } else if (value === "updated") {
-          outro("💠 Dependencies updated successfully!")
+          outro("✅ Dependencies updated successfully!")
         }
 
         process.exit(0)
@@ -98,7 +99,6 @@ export default defineCommand({
         if (Fault.isFault(error) && error.tag === "OPERATION_CANCELLED") {
           cancel("You've cancelled the update process.")
           process.exit(0)
-          return
         }
 
         if (Fault.isFault(error)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,18 @@
 import type { ParseError } from "jsonc-parser"
 
-interface CommonErrors {
-  FAILED_TO_PARSE_FILE: { path?: string; errors?: ParseError[] }
-  FAILED_TO_RUN_COMMAND: { command?: string }
-  FILE_NOT_FOUND: { path?: string }
-  NO_PACKAGE_MANAGER: never
-  FAILED_TO_WRITE_FILE: { path?: string }
-  FAILED_TO_READ_FILE: { path?: string }
-  FAILED_TO_CREATE_DIRECTORY: { path?: string }
-  FAILED_TO_MERGE_CONFIG: { path?: string }
-  OPERATION_CANCELLED: never
-}
-
-interface InitErrors {
-  FAILED_TO_INSTALL_DEPENDENCY: never
-}
-
-interface BiomeError {
-  INVALID_BIOME_CONFIG: { path?: string }
-}
-
 declare module "faultier" {
-  interface FaultRegistry extends CommonErrors, BiomeError, InitErrors {}
+  interface FaultRegistry {
+    FAILED_TO_CREATE_DIRECTORY: { path?: string }
+    FAILED_TO_INSTALL_DEPENDENCY: never
+    FAILED_TO_MERGE_CONFIG: { path?: string }
+    FAILED_TO_PARSE_FILE: { path?: string; errors?: ParseError[] }
+    FAILED_TO_READ_FILE: { path?: string }
+    FAILED_TO_RUN_COMMAND: { command?: string }
+    FAILED_TO_WRITE_FILE: { path?: string }
+    FILE_NOT_FOUND: { path?: string }
+    INVALID_BIOME_CONFIG: { path?: string }
+    NO_PACKAGE_MANAGER: never
+    OPERATION_CANCELLED: never
+    UNKNOWN_SCRIPT: { script: string }
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import process from "node:process"
 import defu from "defu"
 import { Fault } from "faultier"
 import { type ParseError, parse } from "jsonc-parser"
-import { err, fromPromise, fromThrowable, ok } from "neverthrow"
+import { err, fromPromise, fromThrowable, ok, safeTry } from "neverthrow"
 import { detectPackageManager } from "nypm"
 import type { PackageJson } from "type-fest"
 import type { CommandModule } from "yargs"
@@ -76,25 +76,32 @@ export const readPackageJson = (cwd = process.cwd()) =>
     .andThen((content) => parseJson(content))
     .andThen((parsed) => ok(parsed as unknown as PackageJson))
 
-export function getTitle() {
-  const terminalWidth = process.stdout.columns || 80
+export const checkIsMonorepo = () =>
+  safeTry(async function* () {
+    const pnpmWorkspace = await checkIfExists(join(process.cwd(), "pnpm-workspace.yaml"))
 
-  if (terminalWidth >= 120) {
-    return `
-               █████                                                 █████     ███   █████            
-              ░░███                                                 ░░███     ░░░   ░░███             
-  ██████    ███████   ██████   █████████████    ██████   ████████   ███████   ████  ███████    ██████ 
- ░░░░░███  ███░░███  ░░░░░███ ░░███░░███░░███  ░░░░░███ ░░███░░███ ░░░███░   ░░███ ░░░███░    ███░░███
-  ███████ ░███ ░███   ███████  ░███ ░███ ░███   ███████  ░███ ░███   ░███     ░███   ░███    ░███████ 
- ███░░███ ░███ ░███  ███░░███  ░███ ░███ ░███  ███░░███  ░███ ░███   ░███ ███ ░███   ░███ ███░███░░░  
-░░████████░░████████░░████████ █████░███ █████░░████████ ████ █████  ░░█████  █████  ░░█████ ░░██████ 
- ░░░░░░░░  ░░░░░░░░  ░░░░░░░░ ░░░░░ ░░░ ░░░░░  ░░░░░░░░ ░░░░ ░░░░░    ░░░░░  ░░░░░    ░░░░░   ░░░░░░                   
+    if (pnpmWorkspace) {
+      return ok(true)
+    }
+
+    const packageJson = yield* readPackageJson()
+
+    return ok(packageJson?.workspaces !== undefined)
+  })
+
+const TITLE = `
+     o      ooooooooo      o      oooo     oooo      o      oooo   oooo ooooooooooo ooooo ooooooooooo ooooooooooo
+    888      888    88o   888      8888o   888      888      8888o  88  88  888  88  888  88  888  88  888    88 
+   8  88     888    888  8  88     88 888o8 88     8  88     88 888o88      888      888      888      888ooo8   
+  8oooo88    888    888 8oooo88    88  888  88    8oooo88    88   8888      888      888      888      888    oo 
+o88o  o888o o888ooo88 o88o  o888o o88o  8  o88o o88o  o888o o88o    88     o888o    o888o    o888o    o888ooo8888                                                                       
 `
+
+export function printTitle() {
+  const columns = TITLE.split("\n").reduce((max, line) => Math.max(max, line.trim().length), 0)
+
+  if (process.stdout.columns && process.stdout.columns >= columns) {
+    // biome-ignore lint/suspicious/noConsole: we're using console.log to print the title
+    console.log(TITLE)
   }
-
-  return `
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃                              ADAMANTITE                              ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances CLI UX and safety, and adds broad test coverage.
> 
> - **Init UX**: Switches to `@clack/prompts` v1, adds `printTitle`, auto-detects monorepos, and lets users pick specific scripts (`check`, `fix`, `check:monorepo`, `fix:monorepo`); installs only needed deps and configures Biome/TypeScript/VSCode accordingly
> - **Monorepo behavior**: `adamantite monorepo` now checks by default; requires `--fix` to modify files
> - **Commands polish**: Clearer `check`/`fix` descriptions; `update` prints title and friendlier status output
> - **Utils/Types**: New `checkIsMonorepo`, `printTitle`; expands Fault types (e.g., `UNKNOWN_SCRIPT`, write/read/merge errors)
> - **Tests**: Adds command, helper integration, and utils tests (including error paths and package manager detection)
> - **Docs/Deps**: Updates README/AGENTS; bumps `@clack/prompts` to `1.0.0-alpha.9`; adds `test:coverage` script; adds changeset for minor release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d63ba0d375055972ad1242058968cce68c55b5d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced init command with interactive prompts, automatic monorepo detection, and granular script installation options (check, fix, check:monorepo, fix:monorepo).
  * Monorepo command now requires `--fix` flag to auto-fix issues; without it, performs checks only for safer operation.

* **Documentation**
  * Updated command descriptions and added documentation for the new `--fix` flag behavior.

* **Tests**
  * Added comprehensive CLI command tests and integration tests for failure scenarios.

* **Chores**
  * Upgraded @clack/prompts dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->