### PR TITLE
Adamantite export path update

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install --save-dev adamantite @biomejs/biome
 echo '{ "extends": ["adamantite"] }' > biome.jsonc
 
 # Extend TypeScript configuration
-echo '{ "extends": "adamantite/tsconfig" }' > tsconfig.json
+echo '{ "extends": "adamantite/typescript" }' > tsconfig.json
 ```
 
 ## 📋 Commands

--- a/__tests__/helpers.integration.test.ts
+++ b/__tests__/helpers.integration.test.ts
@@ -278,7 +278,7 @@ describe("helpers integration", () => {
       const config = JSON.parse(content)
 
       expect(config).toHaveProperty("extends")
-      expect(config.extends).toBe("adamantite/tsconfig")
+      expect(config.extends).toBe("adamantite/typescript")
     })
 
     test("should update existing tsconfig.json config", async () => {
@@ -313,7 +313,7 @@ describe("helpers integration", () => {
         strict: true,
       })
       expect(config.include).toEqual(["src/**/*"])
-      expect(config.extends).toBe("adamantite/tsconfig")
+      expect(config.extends).toBe("adamantite/typescript")
     })
 
     test("should preserve existing extends when updating", async () => {
@@ -339,7 +339,7 @@ describe("helpers integration", () => {
       const config = JSON.parse(content)
 
       // Our extends should override existing extends
-      expect(config.extends).toBe("adamantite/tsconfig")
+      expect(config.extends).toBe("adamantite/typescript")
       expect(config.compilerOptions).toEqual({ target: "ES2020" })
     })
 

--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -85,7 +85,7 @@ describe("helpers", () => {
   describe("tsconfig", () => {
     test("should provide a config that extends adamantite tsconfig preset", () => {
       expect(tsconfig.config).toHaveProperty("extends")
-      expect(tsconfig.config.extends).toBe("adamantite/tsconfig")
+      expect(tsconfig.config.extends).toBe("adamantite/typescript")
     })
   })
 

--- a/src/helpers/tsconfig.ts
+++ b/src/helpers/tsconfig.ts
@@ -5,7 +5,7 @@ import { fromPromise, ok, safeTry } from "neverthrow"
 import { checkIfExists, mergeConfig, parseJson } from "#utils.ts"
 
 export const tsconfig = {
-  config: { extends: "adamantite/tsconfig" },
+  config: { extends: "adamantite/typescript" },
   exists: () => checkIfExists(join(process.cwd(), "tsconfig.json")),
   create: () =>
     fromPromise(


### PR DESCRIPTION
Update TypeScript config extends paths to `adamantite/typescript` to match the new export path in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-aaae98e9-ef16-4fa4-8010-004d6ec299e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aaae98e9-ef16-4fa4-8010-004d6ec299e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

