### PR TITLE
Fix preset declaration types to allow extension without leaking readonly literal arrays

### DIFF
--- a/.changeset/giant-rabbits-lay.md
+++ b/.changeset/giant-rabbits-lay.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Fix preset declaration types so lint, format, and analyze presets can be extended without leaking readonly literal arrays into consumer configs.

--- a/presets/analyze.ts
+++ b/presets/analyze.ts
@@ -1,6 +1,6 @@
-import type { KnipConfig } from "knip"
+import type { KnipConfiguration } from "knip"
 
-export default {
+const config: KnipConfiguration = {
   ignore: ["**/*.d.ts"],
   ignoreExportsUsedInFile: true,
   ignoreFiles: [
@@ -28,4 +28,6 @@ export default {
     unlisted: "error",
     unresolved: "error",
   },
-} as const satisfies KnipConfig
+}
+
+export default config

--- a/presets/format.ts
+++ b/presets/format.ts
@@ -1,6 +1,6 @@
 import type { FormatConfig } from "oxfmt"
 
-export default {
+const config: FormatConfig = {
   arrowParens: "always",
   bracketSameLine: false,
   bracketSpacing: true,
@@ -58,4 +58,6 @@ export default {
   tabWidth: 2,
   trailingComma: "es5",
   useTabs: false,
-} as const satisfies FormatConfig
+}
+
+export default config

--- a/presets/lint/core.ts
+++ b/presets/lint/core.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["eslint", "typescript", "unicorn", "oxc", "import", "jsdoc", "promise"],
   rules: {
     "accessor-pairs": "error",
@@ -462,4 +462,6 @@ export default {
     "vars-on-top": "error",
     yoda: "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/jest.ts
+++ b/presets/lint/jest.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["jest"],
   rules: {
     "jest/consistent-test-it": "error",
@@ -59,4 +59,6 @@ export default {
     "jest/valid-expect-in-promise": "error",
     "jest/valid-title": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/nextjs.ts
+++ b/presets/lint/nextjs.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["nextjs"],
   rules: {
     "nextjs/google-font-display": "error",
@@ -25,4 +25,6 @@ export default {
     "nextjs/no-typos": "error",
     "nextjs/no-unwanted-polyfillio": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/node.ts
+++ b/presets/lint/node.ts
@@ -1,10 +1,12 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["node"],
   rules: {
     "node/no-exports-assign": "error",
     "node/no-new-require": "error",
     "node/no-path-concat": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/react.ts
+++ b/presets/lint/react.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["react", "react-perf", "jsx-a11y"],
   rules: {
     "jsx-a11y/alt-text": "error",
@@ -80,4 +80,6 @@ export default {
     "react/style-prop-object": "error",
     "react/void-dom-elements-no-children": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/vitest.ts
+++ b/presets/lint/vitest.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["vitest"],
   rules: {
     "vitest/consistent-each-for": "error",
@@ -21,4 +21,6 @@ export default {
     "vitest/require-local-test-context-for-concurrent-snapshots": "error",
     "vitest/require-mock-type-parameters": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config

--- a/presets/lint/vue.ts
+++ b/presets/lint/vue.ts
@@ -1,6 +1,6 @@
 import type { OxlintConfig } from "oxlint"
 
-export default {
+const config: OxlintConfig = {
   plugins: ["vue"],
   rules: {
     "vue/define-emits-declaration": "error",
@@ -20,4 +20,6 @@ export default {
     "vue/valid-define-emits": "error",
     "vue/valid-define-props": "error",
   },
-} as const satisfies OxlintConfig
+}
+
+export default config


### PR DESCRIPTION
Replace `as const satisfies` pattern with explicit typed variable declarations across all preset files to prevent readonly literal arrays from leaking into consumer configs when extending presets.

The previous approach of using `as const satisfies <Type>` caused readonly literal array types to be inferred and exposed to consumers, making it impossible to extend preset configurations without TypeScript errors. By declaring each preset as an explicitly typed `const config: <Type>` variable instead, the types remain mutable and compatible with consumer-side config merging and extension.

The `analyze` preset also switches from `KnipConfig` to the more appropriate `KnipConfiguration` type.