### PR TITLE
fix: replace invalid jsx-a11y rule name with anchor-ambiguous-text

### DIFF
--- a/.changeset/brave-rules-lint.md
+++ b/.changeset/brave-rules-lint.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Fix the React lint preset to use Oxlint's supported `jsx-a11y/anchor-ambiguous-text` rule.

--- a/presets/lint/react.ts
+++ b/presets/lint/react.ts
@@ -21,7 +21,7 @@ const config: OxlintConfig = {
     "jsx-a11y/media-has-caption": "error",
     "jsx-a11y/mouse-events-have-key-events": "error",
     "jsx-a11y/no-access-key": "error",
-    "jsx-a11y/no-ambiguous-text": "error",
+    "jsx-a11y/anchor-ambiguous-text": "error",
     "jsx-a11y/no-aria-hidden-on-focusable": "error",
     "jsx-a11y/no-autofocus": "error",
     "jsx-a11y/no-distracting-elements": "error",

--- a/presets/lint/react.ts
+++ b/presets/lint/react.ts
@@ -4,6 +4,7 @@ const config: OxlintConfig = {
   plugins: ["react", "react-perf", "jsx-a11y"],
   rules: {
     "jsx-a11y/alt-text": "error",
+    "jsx-a11y/anchor-ambiguous-text": "error",
     "jsx-a11y/anchor-has-content": "error",
     "jsx-a11y/anchor-is-valid": "error",
     "jsx-a11y/aria-activedescendant-has-tabindex": "error",
@@ -21,7 +22,6 @@ const config: OxlintConfig = {
     "jsx-a11y/media-has-caption": "error",
     "jsx-a11y/mouse-events-have-key-events": "error",
     "jsx-a11y/no-access-key": "error",
-    "jsx-a11y/anchor-ambiguous-text": "error",
     "jsx-a11y/no-aria-hidden-on-focusable": "error",
     "jsx-a11y/no-autofocus": "error",
     "jsx-a11y/no-distracting-elements": "error",


### PR DESCRIPTION
Replace the invalid jsx-a11y/no-ambiguous-text rule with the correct Oxlint rule name jsx-a11y/anchor-ambiguous-text.

Related documentation: https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/anchor-ambiguous-text.html