### PR TITLE
Add CONTEXT.md, agent skill docs, and refactor AGENTS.md to reference them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,20 @@
 
 This project was built with [`pastry`](https://github.com/adelrodriguez/pastry) template.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked as GitHub issues at `adelrodriguez/adamantite` (via the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default triage vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
 ## Quality Control
 
 - We use `adamantite` for linting, formatting and type checking.
@@ -19,12 +33,8 @@ This project was built with [`pastry`](https://github.com/adelrodriguez/pastry) 
 
 ## Project Overview
 
-Adamantite is an opinionated preset package for modern TypeScript applications that provides:
-
-- **oxlint configuration** (`presets/lint/*.ts`) - Modular linting rules (core, React, Next.js)
-- **oxfmt configuration** (`presets/format.ts`) - Code formatting configuration
-- **TypeScript preset** (`presets/tsconfig.json`) - Strict TypeScript configuration
-- **CLI tool** - Commands to run oxlint linting and oxfmt formatting via `adamantite` command
+For what Adamantite is, its domain vocabulary, the integration lifecycle verbs, and the
+codebase map, see `CONTEXT.md`.
 
 ## Development Commands
 
@@ -65,58 +75,26 @@ This project uses changesets for version management:
 
 ## Architecture
 
+For domain definitions (integration, migration, lifecycle verbs, managed script), the
+codebase map, the build pipeline, and the preset files, see `CONTEXT.md`. The rules below
+are the guardrails to follow when working in those areas.
+
 ### Integration Boundaries
 
-- Integration modules under `src/lib/integrations/**` should only export the integration itself (default export). Keep extra helpers out of those files. `src/lib/integrations/base.ts` is the shared infrastructure exception.
+- Integration modules should only export the integration itself (default export). Keep extra helpers out of those files. `src/lib/integrations/base.ts` is the shared infrastructure exception.
 - If integration-related logic needs to be reused, move it to a nearby non-integration module such as `src/lib/workspace/**` or `src/lib/shared/**` instead of adding named exports to an integration file.
 - Keep one-off transition logic in `src/lib/migrations/**`. Do not move migration behavior into integration files just to simplify command wiring.
 - Keep `init` simple. It should not import migration helpers or perform migration-specific orchestration.
 - When `init` finds existing setup that it intentionally leaves alone, prefer warning and follow-up guidance over mutation. Point users to `adamantite doctor` / `adamantite doctor --fix` for verification and safe local fixes.
 
-### Integration Lifecycle
+### Integration Lifecycle Invariants
 
-- `exists` answers whether the latest supported config is present and active.
-- `create` writes the latest supported config from scratch.
-- `update` safely rewrites an existing latest-format config into the latest supported shape.
-- `migrations` handle transitions that fall outside `exists` / `create` / `update`, such as legacy formats, legacy scripts, or one-off upgrades.
-- `assess` is read-only. It may classify package drift, missing config, supported config updates, manual follow-up work, and known migrations, but it must not mutate files or call migrations.
-- `doctor --fix` dispatches `create_config` through `create`, `update_config` through `update`, and `run_migration` through the migration system. `manual_fix` is report-only.
-- Migrations may call integrations to get the project into the latest supported shape. Integrations must not call migrations.
-
-### Workspace Conventions
-
-- Managed script types and helpers live in `src/lib/workspace/package-json.ts`. Import `Script`, `MANAGED_SCRIPT_COMMANDS`, and `getManagedScripts` from there.
-
-### CLI Structure (`src/`)
-
-- **`index.ts`** - Main CLI entry point using yargs
-- **`commands/`** - Command implementations:
-  - `fix.ts` - Runs oxlint to fix issues
-  - `check.ts` - Runs oxlint to check for issues
-  - `format.ts` - Runs oxfmt for code formatting
-  - `init.ts` - Initializes Adamantite configuration
-  - `monorepo.ts` - Runs monorepo-specific checks (use `--fix` to auto-fix issues)
-  - `update.ts` - Updates Adamantite configuration
-- **`lib/`** - Internal library code grouped by concern:
-  - `services/` - Effect services used by commands
-  - `integrations/` - Adapters for tooling, editors, and CI
-  - `workspace/` - Logic that operates on the target project on disk
-  - `shared/` - Cross-cutting utilities and error types
-- **`version.ts`** - Package version detection
+- `assess` is read-only: it must not mutate files or call migrations.
+- `doctor --fix` is the only mutating dispatcher; `manual_fix` is report-only.
+- Migrations may call integrations to reach the latest supported shape. Integrations must not call migrations.
 
 ### Dependency Management
 
-Adamantite depends on multiple packages to perform its tasks. These dependencies are defined inside the `src/lib/integrations/tooling/` directory.
-
-Each package has a version property that is used to determine the version of the package to install, and it should match the version of the package in the `package.json` file. If the version in the `package.json` file is higher, we should update the version in its respective integration object.
-
-### Build Process
-
-- **bunup** (`bunup.config.ts`) bundles CLI to `dist/index.js` with minification
-- Entry point: `src/index.ts` → Output: `dist/index.js` (executable via `adamantite` command)
-
-### Configuration Files
-
-- **`presets/lint/core.ts`** - Core linting rules for all TypeScript/JavaScript projects
-- **`presets/format.ts`** - Code formatting configuration
-- **`presets/tsconfig.json`** - Reusable TypeScript configuration
+When a tooling dependency's version in `package.json` is higher than the version recorded
+in its `src/lib/integrations/tooling/` integration object, update the integration object
+to match.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,87 @@
+# Context
+
+Domain language and orientation for Adamantite. Read this before exploring or changing
+code so you use the project's own terms instead of inventing synonyms. This file
+describes _what things mean_; standing rules and commands live in `AGENTS.md`.
+
+## What Adamantite is
+
+Adamantite is an opinionated **preset** package for modern TypeScript applications. It
+ships configuration and a CLI that applies and maintains that configuration in a target
+project. It provides:
+
+- **oxlint configuration** (`presets/lint/*.ts`) — modular linting rules (core, React, Next.js)
+- **oxfmt configuration** (`presets/format.ts`) — code formatting configuration
+- **TypeScript preset** (`presets/tsconfig.json`) — strict TypeScript configuration
+- **CLI tool** — commands to run oxlint linting and oxfmt formatting via the `adamantite` command
+
+## Glossary
+
+- **Preset** — the shipped configuration under `presets/` (lint, format, tsconfig) that
+  a target project consumes.
+- **Target project** — the user's repository that Adamantite is configuring. Distinct
+  from _this_ repository (the Adamantite source itself).
+- **Integration** — an adapter under `src/lib/integrations/**` for a tool, editor, or CI
+  system. Each integration module exports only the integration itself (default export);
+  `src/lib/integrations/base.ts` is the shared-infrastructure exception.
+- **Migration** — one-off transition logic under `src/lib/migrations/**` that handles
+  upgrades falling outside an integration's normal lifecycle (legacy formats, legacy
+  scripts, one-off upgrades).
+- **Managed script** — a `package.json` script entry Adamantite owns. Types and helpers
+  (`Script`, `MANAGED_SCRIPT_COMMANDS`, `getManagedScripts`) live in
+  `src/lib/workspace/package-json.ts`.
+
+### Integration lifecycle verbs
+
+Every integration is described by these operations:
+
+- **`exists`** — answers whether the latest supported config is present and active.
+- **`create`** — writes the latest supported config from scratch.
+- **`update`** — safely rewrites an existing latest-format config into the latest
+  supported shape.
+- **`migrations`** — handle transitions that fall outside `exists` / `create` /
+  `update`, such as legacy formats, legacy scripts, or one-off upgrades.
+- **`assess`** — read-only. Classifies package drift, missing config, supported config
+  updates, manual follow-up work, and known migrations. It does not mutate files or call
+  migrations.
+- **`doctor` / `doctor --fix`** — `doctor --fix` dispatches `create_config` through
+  `create`, `update_config` through `update`, and `run_migration` through the migration
+  system. `manual_fix` is report-only.
+
+## Codebase map
+
+### CLI structure (`src/`)
+
+- **`index.ts`** — main CLI entry point using yargs
+- **`commands/`** — command implementations:
+  - `fix.ts` — runs oxlint to fix issues
+  - `check.ts` — runs oxlint to check for issues
+  - `format.ts` — runs oxfmt for code formatting
+  - `init.ts` — initializes Adamantite configuration
+  - `monorepo.ts` — runs monorepo-specific checks (use `--fix` to auto-fix issues)
+  - `update.ts` — updates Adamantite configuration
+- **`lib/`** — internal library code grouped by concern:
+  - `services/` — Effect services used by commands
+  - `integrations/` — adapters for tooling, editors, and CI
+  - `workspace/` — logic that operates on the target project on disk
+  - `shared/` — cross-cutting utilities and error types
+- **`version.ts`** — package version detection
+
+### Preset / configuration files
+
+- **`presets/lint/core.ts`** — core linting rules for all TypeScript/JavaScript projects
+- **`presets/format.ts`** — code formatting configuration
+- **`presets/tsconfig.json`** — reusable TypeScript configuration
+
+### Build pipeline
+
+- **bunup** (`bunup.config.ts`) bundles the CLI to `dist/index.js` with minification.
+- Entry point: `src/index.ts` → output: `dist/index.js` (executable via the `adamantite`
+  command).
+
+### Dependencies on tooling
+
+Adamantite depends on multiple packages to perform its tasks. These dependencies are
+defined inside the `src/lib/integrations/tooling/` directory. Each package has a version
+property used to determine the version to install; it should match the version in
+`package.json`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments` for human-readable output. For scripted use, fetch JSON with `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Add `CONTEXT.md` and agent skill documentation for issue tracking, triage, and domain orientation

Introduces a `CONTEXT.md` at the repo root as the single authoritative source for domain vocabulary, the integration lifecycle verbs, the codebase map, the build pipeline, and preset file descriptions. `AGENTS.md` now points to `CONTEXT.md` for those topics rather than duplicating them inline, keeping `AGENTS.md` focused on guardrails and development commands.

Adds three agent skill documents under `docs/agents/`:

- **`issue-tracker.md`** — describes how to create, read, list, comment on, label, and close GitHub issues via the `gh` CLI.
- **`triage-labels.md`** — maps the five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to the label strings used in this repo.
- **`domain.md`** — instructs agents to read `CONTEXT.md` and relevant ADRs before exploring the codebase, use the glossary's vocabulary in all output, and surface any contradictions with existing ADRs explicitly.

The `AGENTS.md` Architecture section is trimmed to invariants only: `assess` is read-only, `doctor --fix` is the sole mutating dispatcher, and integrations must not call migrations. The dependency management rule is simplified to a single actionable instruction about keeping integration version properties in sync with `package.json`.