### PR TITLE
Add optional `AGENTS.md` guidance step to `adamantite init` with idempotent marker-based updates

### DIFF
--- a/.changeset/sharp-agents-guide.md
+++ b/.changeset/sharp-agents-guide.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Add optional `AGENTS.md` guidance during `adamantite init` with idempotent Adamantite marker updates.

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
-import { readFile, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import Bun from "bun"
@@ -16,6 +16,10 @@ import sherif from "#lib/integrations/tooling/sherif.ts"
 import tsgolint from "#lib/integrations/tooling/tsgolint.ts"
 import { CliNotFound } from "#lib/shared/errors.ts"
 import {
+  ADAMANTITE_AGENTS_END_MARKER,
+  ADAMANTITE_AGENTS_START_MARKER,
+} from "#lib/workspace/agents.ts"
+import {
   createDependencyInstallerTestContext,
   createRunnerTestContext,
   createPrompterTestContext,
@@ -24,6 +28,10 @@ import {
 
 async function readJson<T = Record<string, unknown>>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, "utf8")) as T
+}
+
+function countOccurrences(content: string, search: string) {
+  return content.split(search).length - 1
 }
 
 describe("init", () => {
@@ -56,7 +64,7 @@ describe("init", () => {
   describe("fresh project setup", () => {
     test("set up the selected files, scripts, and dependencies", async () => {
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, false, false],
+        confirmResponses: [true, false, false, false],
         multiselectResponses: [["check", "format", "analyze"], ["react"], ["vscode"]],
       })
       const installer = createDependencyInstallerTestContext()
@@ -133,7 +141,7 @@ describe("init", () => {
       )
 
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, false],
+        confirmResponses: [true, false, false],
         multiselectResponses: [["check"], ["react"], []],
       })
       const installer = createDependencyInstallerTestContext()
@@ -273,7 +281,7 @@ describe("init", () => {
       )
 
       const prompter = createPrompterTestContext({
-        confirmResponses: [false],
+        confirmResponses: [false, false],
         multiselectResponses: [["check:monorepo"], []],
       })
       const installer = createDependencyInstallerTestContext()
@@ -324,7 +332,7 @@ describe("init", () => {
       )
 
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, false, false],
+        confirmResponses: [true, false, false, false],
         multiselectResponses: [["check", "format"], [], ["vscode"]],
       })
       const installer = createDependencyInstallerTestContext()
@@ -357,7 +365,7 @@ describe("init", () => {
   describe("selective setup", () => {
     test("apply only the requested scripts and editor setup", async () => {
       const prompter = createPrompterTestContext({
-        confirmResponses: [false, false],
+        confirmResponses: [false, false, false],
         multiselectResponses: [["format"], ["zed"]],
       })
       const installer = createDependencyInstallerTestContext()
@@ -383,6 +391,193 @@ describe("init", () => {
       expect(await Bun.file(join(tempDir, "tsconfig.json")).exists()).toBe(false)
       expect(await Bun.file(join(tempDir, "knip.config.ts")).exists()).toBe(false)
       expect(await Bun.file(join(tempDir, ".vscode", "settings.json")).exists()).toBe(false)
+    })
+  })
+
+  describe("agents guidance", () => {
+    test("adds script-specific Adamantite guidance to AGENTS.md when confirmed", async () => {
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, false, true],
+        multiselectResponses: [["check", "format", "analyze"], [], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+      expect(agents).toContain(ADAMANTITE_AGENTS_START_MARKER)
+      expect(agents).toContain("## Adamantite")
+      expect(agents).toContain("Run `bun run format` after editing files")
+      expect(agents).toContain("Run `bun run check` to catch lint and type issues")
+      expect(agents).toContain("Run `bun run analyze` after changing dependencies")
+      expect(agents).toContain("adamantite doctor --fix")
+      expect(agents).not.toContain("adamantite fix")
+      expect(agents).toContain(ADAMANTITE_AGENTS_END_MARKER)
+      expect(agents.endsWith("\n")).toBe(true)
+    })
+
+    test("uses the detected package manager in AGENTS.md guidance", async () => {
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext({
+        detectedPackageManager: { name: "npm" },
+      })
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+      expect(agents).toContain("Run `npm run format` after editing files")
+    })
+
+    test("appends Adamantite guidance to an existing AGENTS.md without markers", async () => {
+      const existingAgents = "# Existing Instructions\n\nKeep project guidance here.\n"
+      await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+      expect(agents.startsWith(`${existingAgents}\n${ADAMANTITE_AGENTS_START_MARKER}\n`)).toBe(true)
+      expect(agents).toContain("## Adamantite")
+      expect(agents).toContain(ADAMANTITE_AGENTS_END_MARKER)
+    })
+
+    test("replaces existing Adamantite guidance without duplicating markers", async () => {
+      await writeFile(
+        join(tempDir, "AGENTS.md"),
+        `# Existing Instructions\n\n${ADAMANTITE_AGENTS_START_MARKER}\nold content\n${ADAMANTITE_AGENTS_END_MARKER}\n`
+      )
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["analyze"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+      expect(agents).toContain("# Existing Instructions")
+      expect(agents).toContain("Run `bun run analyze` after changing dependencies")
+      expect(agents).not.toContain("old content")
+      expect(countOccurrences(agents, ADAMANTITE_AGENTS_START_MARKER)).toBe(1)
+      expect(countOccurrences(agents, ADAMANTITE_AGENTS_END_MARKER)).toBe(1)
+    })
+
+    test("leaves AGENTS.md unchanged when Adamantite start marker is missing its end marker", async () => {
+      const existingAgents = `# Existing Instructions\n\n${ADAMANTITE_AGENTS_START_MARKER}\nmanual content\n`
+      await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message:
+          "Could not update AGENTS.md because Adamantite markers are incomplete. Remove the stale ADAMANTITE marker and run adamantite init again.",
+      })
+      expect(await readFile(join(tempDir, "AGENTS.md"), "utf8")).toBe(existingAgents)
+    })
+
+    test("leaves AGENTS.md unchanged when Adamantite end marker is missing its start marker", async () => {
+      const existingAgents = `# Existing Instructions\n\nmanual content\n${ADAMANTITE_AGENTS_END_MARKER}\n`
+      await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message:
+          "Could not update AGENTS.md because Adamantite markers are incomplete. Remove the stale ADAMANTITE marker and run adamantite init again.",
+      })
+      expect(await readFile(join(tempDir, "AGENTS.md"), "utf8")).toBe(existingAgents)
+    })
+
+    test("leaves AGENTS.md unchanged when guidance is declined", async () => {
+      const existingAgents = "# Existing Instructions\n"
+      await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, false],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(await readFile(join(tempDir, "AGENTS.md"), "utf8")).toBe(existingAgents)
+    })
+
+    test("continues initialization when AGENTS.md cannot be read", async () => {
+      const agentsPath = join(tempDir, "AGENTS.md")
+      await mkdir(agentsPath)
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, true],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message: expect.stringMatching(
+          /Could not update AGENTS\.md\. Failed to read `.*\/AGENTS\.md`\. Adamantite will continue initialization\./
+        ),
+      })
+      expect(prompter.logs).toContainEqual({
+        level: "success",
+        message: "Your project is now configured",
+      })
+      expect(prompter.outros).toEqual(["💠 Adamantite initialized successfully!"])
+    })
+
+    test("gracefully handles AGENTS.md prompt cancellation", async () => {
+      const prompter = createPrompterTestContext({
+        cancelAtPromptIndex: 4,
+        confirmResponses: [false],
+        multiselectResponses: [["format"], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.cancels).toEqual(["You've cancelled the initialization process."])
+      expect(prompter.outros).toEqual([])
+      expect(installer.calls).toEqual([])
+      expect(await Bun.file(join(tempDir, "AGENTS.md")).exists()).toBe(false)
     })
   })
 
@@ -449,7 +644,7 @@ describe("init", () => {
       )
 
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, false],
+        confirmResponses: [true, false, false],
         multiselectResponses: [["check"], [], []],
       })
       const installer = createDependencyInstallerTestContext()
@@ -482,7 +677,7 @@ describe("init", () => {
 
     test("create a GitHub Actions workflow for CI-compatible scripts when requested", async () => {
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, true, true],
+        confirmResponses: [true, true, true, false],
         multiselectResponses: [["check", "format"], ["react"], ["zed"]],
       })
       const installer = createDependencyInstallerTestContext()
@@ -515,7 +710,7 @@ describe("init", () => {
 
     test("skip tsconfig setup when the user declines the TypeScript preset prompt", async () => {
       const prompter = createPrompterTestContext({
-        confirmResponses: [false, false],
+        confirmResponses: [false, false, false],
         multiselectResponses: [["check"], [], []],
       })
       const installer = createDependencyInstallerTestContext()
@@ -553,7 +748,7 @@ describe("init", () => {
 
     test("continue successfully and show guidance when the VS Code CLI is unavailable", async () => {
       const prompter = createPrompterTestContext({
-        confirmResponses: [true, false],
+        confirmResponses: [true, false, false],
         multiselectResponses: [["format"], ["vscode"]],
       })
       const installer = createDependencyInstallerTestContext()

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import process from "node:process"
+import type { PackageManagerName } from "nypm"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
@@ -15,6 +16,7 @@ import { DependencyInstaller } from "#lib/services/dependency-installer.ts"
 import { Prompter } from "#lib/services/prompter.ts"
 import { FailedToWriteFile, NoPackageManager, UnknownScript } from "#lib/shared/errors.ts"
 import { printTitle } from "#lib/shared/terminal.ts"
+import { writeAgentsGuidance } from "#lib/workspace/agents.ts"
 import { hasCICompatibleScripts } from "#lib/workspace/ci-scripts.ts"
 import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
 import {
@@ -359,6 +361,37 @@ const setupGitHubActions = (
     }
   }).pipe(Effect.option)
 
+const setupAgentsGuidance = (cwd: string, packageManager: PackageManagerName, scripts: Script[]) =>
+  Effect.gen(function* () {
+    const prompter = yield* Prompter
+    const spinner = prompter.spinner()
+    spinner.start("Updating AGENTS.md...")
+
+    const result = yield* writeAgentsGuidance(cwd, { packageManager, scripts }).pipe(
+      Effect.catchTag(["FailedToReadFile", "FailedToWriteFile"], (error) =>
+        Effect.gen(function* () {
+          spinner.stop("Failed to update AGENTS.md.")
+          yield* prompter.log.warning(
+            `Could not update AGENTS.md. ${error.message} Adamantite will continue initialization.`
+          )
+          return "failed" as const
+        })
+      )
+    )
+
+    if (result === "failed") {
+      return
+    }
+
+    spinner.stop("AGENTS.md check complete.")
+
+    if (result === "malformed") {
+      yield* prompter.log.warning(
+        "Could not update AGENTS.md because Adamantite markers are incomplete. Remove the stale ADAMANTITE marker and run adamantite init again."
+      )
+    }
+  })
+
 export default Command.make("init").pipe(
   Command.withDescription("Initialize Adamantite in the current directory"),
   Command.withHandler(() =>
@@ -489,6 +522,12 @@ export default Command.make("init").pipe(
         enableGitHubActions = enableGitHubActionsResponse
       }
 
+      const shouldAddAgentsGuidance = yield* prompter.confirm({
+        initialValue: true,
+        message:
+          "Add Adamantite guidance to AGENTS.md so coding agents know how to run project checks?",
+      })
+
       const hasOxfmt = selectedScripts.includes("format")
       const hasSherif =
         selectedScripts.includes("check:monorepo") || selectedScripts.includes("fix:monorepo")
@@ -530,6 +569,10 @@ export default Command.make("init").pipe(
       }
 
       yield* addScripts(cwd, selectedScripts)
+
+      if (shouldAddAgentsGuidance) {
+        yield* setupAgentsGuidance(cwd, packageManager.name, selectedScripts)
+      }
 
       if (shouldSetupTypescript) {
         yield* setupTypescript(cwd)

--- a/src/lib/workspace/__tests__/agents.test.ts
+++ b/src/lib/workspace/__tests__/agents.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import * as NodeServices from "@effect/platform-node/NodeServices"
+import Bun from "bun"
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as PlatformError from "effect/PlatformError"
+import {
+  ADAMANTITE_AGENTS_END_MARKER,
+  ADAMANTITE_AGENTS_START_MARKER,
+  writeAgentsGuidance,
+} from "#lib/workspace/agents.ts"
+
+function countOccurrences(content: string, search: string) {
+  return content.split(search).length - 1
+}
+
+async function runWriteAgentsGuidance(
+  tempDir: string,
+  options: Parameters<typeof writeAgentsGuidance>[1]
+) {
+  return await writeAgentsGuidance(tempDir, options).pipe(
+    Effect.provide(NodeServices.layer),
+    Effect.runPromise
+  )
+}
+
+describe("writeAgentsGuidance", () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "adamantite-agents-guidance-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { force: true, recursive: true })
+  })
+
+  test("create AGENTS.md when it does not exist", async () => {
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format", "check"],
+    })
+
+    expect(result).toBe("updated")
+
+    const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+    expect(agents).toContain(ADAMANTITE_AGENTS_START_MARKER)
+    expect(agents).toContain("## Adamantite")
+    expect(agents).toContain("Run `bun run format` after editing files")
+    expect(agents).toContain("Run `bun run check` to catch lint and type issues")
+    expect(agents).not.toContain("adamantite analyze")
+    expect(agents).toContain("safe local fixes.\n\n<!-- ADAMANTITE:END -->")
+    expect(agents).toContain(ADAMANTITE_AGENTS_END_MARKER)
+    expect(agents.endsWith("\n")).toBe(true)
+  })
+
+  test("return FailedToReadFile when checking whether AGENTS.md exists fails", async () => {
+    const agentsPath = join(tempDir, "AGENTS.md")
+    const cause = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      method: "access",
+      module: "FileSystem",
+      pathOrDescriptor: agentsPath,
+    })
+    const fileSystemLayer = FileSystem.layerNoop({
+      exists: () => Effect.fail(cause),
+    })
+
+    const result = await writeAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format"],
+    }).pipe(
+      Effect.provide(fileSystemLayer),
+      Effect.provide(NodeServices.layer),
+      Effect.result,
+      Effect.runPromise
+    )
+
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      expect(result.failure).toMatchObject({
+        _tag: "FailedToReadFile",
+        cause,
+        path: agentsPath,
+      })
+    }
+  })
+
+  test("append guidance to an existing AGENTS.md without markers", async () => {
+    const existingAgents = "# Existing Instructions\n\nKeep project guidance here.\n"
+    await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format"],
+    })
+
+    expect(result).toBe("updated")
+
+    const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+    expect(agents.startsWith(`${existingAgents}\n${ADAMANTITE_AGENTS_START_MARKER}\n`)).toBe(true)
+    expect(agents).toContain("Run `bun run format` after editing files")
+  })
+
+  test("preserve an existing blank line when appending guidance", async () => {
+    const existingAgents = "# Existing Instructions\n\nKeep project guidance here.\n\n"
+    await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format"],
+    })
+
+    expect(result).toBe("updated")
+
+    const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+    expect(agents.startsWith(`${existingAgents}${ADAMANTITE_AGENTS_START_MARKER}\n`)).toBe(true)
+  })
+
+  test("replace only the existing Adamantite marker block", async () => {
+    await writeFile(
+      join(tempDir, "AGENTS.md"),
+      [
+        "# Existing Instructions",
+        "",
+        "Keep this before.",
+        ADAMANTITE_AGENTS_START_MARKER,
+        "old content",
+        ADAMANTITE_AGENTS_END_MARKER,
+        "Keep this after.",
+        "",
+      ].join("\n")
+    )
+
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["analyze"],
+    })
+
+    expect(result).toBe("updated")
+
+    const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+    expect(agents).toContain("Keep this before.")
+    expect(agents).toContain("Keep this after.")
+    expect(agents).toContain("Run `bun run analyze` after changing dependencies")
+    expect(agents).not.toContain("old content")
+    expect(countOccurrences(agents, ADAMANTITE_AGENTS_START_MARKER)).toBe(1)
+    expect(countOccurrences(agents, ADAMANTITE_AGENTS_END_MARKER)).toBe(1)
+  })
+
+  test("return malformed and leave AGENTS.md unchanged when start marker has no end marker", async () => {
+    const existingAgents = `# Existing Instructions\n\n${ADAMANTITE_AGENTS_START_MARKER}\nmanual content\n`
+    await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format"],
+    })
+
+    expect(result).toBe("malformed")
+    expect(await readFile(join(tempDir, "AGENTS.md"), "utf8")).toBe(existingAgents)
+  })
+
+  test("return malformed and leave AGENTS.md unchanged when end marker has no start marker", async () => {
+    const existingAgents = `# Existing Instructions\n\nmanual content\n${ADAMANTITE_AGENTS_END_MARKER}\n`
+    await writeFile(join(tempDir, "AGENTS.md"), existingAgents)
+
+    const result = await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["format"],
+    })
+
+    expect(result).toBe("malformed")
+    expect(await readFile(join(tempDir, "AGENTS.md"), "utf8")).toBe(existingAgents)
+  })
+
+  test("generate guidance only for selected scripts", async () => {
+    await runWriteAgentsGuidance(tempDir, {
+      packageManager: "bun",
+      scripts: ["fix", "check:monorepo", "fix:monorepo"],
+    })
+
+    const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+    expect(agents).toContain("Direct command: `adamantite fix`")
+    expect(agents).toContain("Direct command: `adamantite monorepo`")
+    expect(agents).toContain("Direct command: `adamantite monorepo --fix`")
+    expect(agents).not.toContain("adamantite format")
+    expect(agents).not.toContain("adamantite check`")
+    expect(agents).not.toContain("adamantite analyze")
+  })
+
+  test("generate package-manager-specific script commands", async () => {
+    await runWriteAgentsGuidance(tempDir, {
+      packageManager: "npm",
+      scripts: ["format"],
+    })
+
+    const agents = await Bun.file(join(tempDir, "AGENTS.md")).text()
+    expect(agents).toContain("Run `npm run format` after editing files")
+  })
+})

--- a/src/lib/workspace/agents.ts
+++ b/src/lib/workspace/agents.ts
@@ -1,0 +1,114 @@
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as Path from "effect/Path"
+import { runScriptCommand, type PackageManagerName } from "nypm"
+import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
+import { MANAGED_SCRIPT_COMMANDS, type Script } from "#lib/workspace/package-json.ts"
+
+const AGENTS_NAME = "AGENTS.md"
+
+export const ADAMANTITE_AGENTS_START_MARKER = "<!-- ADAMANTITE:START -->"
+export const ADAMANTITE_AGENTS_END_MARKER = "<!-- ADAMANTITE:END -->"
+
+interface WriteAgentsGuidanceOptions {
+  readonly packageManager: PackageManagerName
+  readonly scripts: Script[]
+}
+
+function getScriptGuidance(packageManager: PackageManagerName, script: Script) {
+  const command = runScriptCommand(packageManager, script)
+  const directCommand = MANAGED_SCRIPT_COMMANDS[script]
+
+  switch (script) {
+    case "analyze":
+      return `- Run \`${command}\` after changing dependencies, imports, or exports. Direct command: \`${directCommand}\`.`
+    case "check":
+      return `- Run \`${command}\` to catch lint and type issues. Direct command: \`${directCommand}\`.`
+    case "check:monorepo":
+      return `- Run \`${command}\` to check monorepo package consistency. Direct command: \`${directCommand}\`.`
+    case "fix":
+      return `- Run \`${command}\` to apply safe lint fixes. Direct command: \`${directCommand}\`.`
+    case "fix:monorepo":
+      return `- Run \`${command}\` to fix monorepo package consistency. Direct command: \`${directCommand}\`.`
+    case "format":
+      return `- Run \`${command}\` after editing files. Direct command: \`${directCommand}\`.`
+  }
+}
+
+function getAgentsSection({ packageManager, scripts }: WriteAgentsGuidanceOptions) {
+  const scriptOrder: Script[] = [
+    "format",
+    "check",
+    "fix",
+    "analyze",
+    "check:monorepo",
+    "fix:monorepo",
+  ]
+
+  const selectedScriptGuidance = scriptOrder
+    .filter((script) => scripts.includes(script))
+    .map((script) => getScriptGuidance(packageManager, script))
+
+  const body = [
+    "## Adamantite",
+    "",
+    "This project uses Adamantite for its managed formatting, linting, type checking, and dependency-analysis setup.",
+    "",
+    ...(selectedScriptGuidance.length > 0
+      ? [
+          "- Prefer the package scripts Adamantite added for this workspace.",
+          ...selectedScriptGuidance,
+        ]
+      : []),
+    "- Use `adamantite doctor` to inspect managed setup and `adamantite doctor --fix` for safe local fixes.",
+  ].join("\n")
+
+  return [ADAMANTITE_AGENTS_START_MARKER, "", body, "", ADAMANTITE_AGENTS_END_MARKER, ""].join("\n")
+}
+
+export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOptions) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const agentsPath = path.join(cwd, AGENTS_NAME)
+    const exists = yield* fs
+      .exists(agentsPath)
+      .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: agentsPath })))
+    const existing = exists
+      ? yield* fs
+          .readFileString(agentsPath)
+          .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: agentsPath })))
+      : ""
+    const start = existing.indexOf(ADAMANTITE_AGENTS_START_MARKER)
+    const endMarkerIndex = existing.indexOf(ADAMANTITE_AGENTS_END_MARKER)
+    const section = getAgentsSection(options)
+
+    if (start !== -1 && endMarkerIndex !== -1 && start < endMarkerIndex) {
+      const end = endMarkerIndex + ADAMANTITE_AGENTS_END_MARKER.length
+      const nextContent = `${existing.slice(0, start)}${section.trimEnd()}${existing.slice(end)}`
+
+      yield* fs
+        .writeFileString(agentsPath, nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`)
+        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: agentsPath })))
+
+      return "updated" as const
+    }
+
+    if (start !== -1 || endMarkerIndex !== -1) {
+      return "malformed" as const
+    }
+
+    // Preserve existing trailing content and add only enough newlines for one blank line.
+    const separator =
+      existing.length === 0 || existing.endsWith("\n\n")
+        ? ""
+        : existing.endsWith("\n")
+          ? "\n"
+          : "\n\n"
+
+    yield* fs
+      .writeFileString(agentsPath, `${existing}${separator}${section}`)
+      .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: agentsPath })))
+
+    return "updated" as const
+  })


### PR DESCRIPTION
During `adamantite init`, users are now prompted to add Adamantite-specific guidance to `AGENTS.md` so coding agents know how to run project checks like formatting, linting, type checking, and dependency analysis.

The generated guidance is tailored to the scripts selected during initialization and uses the detected package manager for script commands. When an `AGENTS.md` already exists, the Adamantite section is appended cleanly. If the file already contains Adamantite markers, the section is replaced in place without duplicating content. If only one marker is present without its counterpart, the file is left untouched and a warning is shown directing the user to remove the stale marker before retrying.

Closes https://github.com/adelrodriguez/adamantite/issues/34