### PR TITLE
Remove `react-perf/jsx-no-jsx-as-prop` from React lint preset to allow composition and slot patterns

### DIFF
--- a/.changeset/fair-slots-rest.md
+++ b/.changeset/fair-slots-rest.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Remove `react-perf/jsx-no-jsx-as-prop` from the React lint preset to allow common composition and slot patterns.

--- a/presets/lint/react.ts
+++ b/presets/lint/react.ts
@@ -38,7 +38,6 @@ const config: OxlintConfig = {
     "jsx-a11y/role-supports-aria-props": "error",
     "jsx-a11y/scope": "error",
     "jsx-a11y/tabindex-no-positive": "error",
-    "react-perf/jsx-no-jsx-as-prop": "error",
     "react/button-has-type": "error",
     "react/checked-requires-onchange-or-readonly": "error",
     "react/display-name": "off",


### PR DESCRIPTION
## Remove `react-perf/jsx-no-jsx-as-prop` from React Lint Preset

The `react-perf/jsx-no-jsx-as-prop` rule has been removed from the React lint preset. This rule was too restrictive, preventing common and legitimate composition and slot patterns where JSX elements are passed as props (e.g., `icon={<MyIcon />}` or `header={<Header />}`).