### PR TITLE
Forward arguments after `--` to Knip, Oxlint, Oxfmt, and Sherif commands

### DIFF
--- a/.changeset/bright-tools-pass.md
+++ b/.changeset/bright-tools-pass.md
@@ -1,0 +1,5 @@
+---
+"adamantite": minor
+---
+
+Allow commands that wrap Knip, Oxlint, Oxfmt, or Sherif to forward arguments after `--`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies (bun install)
 node_modules
+.repos/effect
 
 # output
 out

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ This interactive command will:
 
 ## 📋 Commands
 
+### `adamantite analyze`
+
+Find unused dependencies, exports, and files using Knip:
+
+```shell
+# Analyze the current project
+adamantite analyze
+
+# Automatically fix issues, including removing unused files
+adamantite analyze --fix
+
+# Enable production and strict analysis
+adamantite analyze --strict
+
+# Forward additional arguments to Knip
+adamantite analyze -- --directory packages/app
+```
+
 ### `adamantite check`
 
 Check your code for issues and type errors without automatically fixing them using oxlint:
@@ -141,6 +159,30 @@ Automatically detects and fixes:
 - Missing dependencies in package.json
 - Unused dependencies
 - Package.json formatting issues
+
+### Passing arguments to underlying tools
+
+Commands that invoke Knip, Oxlint, Oxfmt, or Sherif can forward additional arguments to
+the underlying CLI. Place Adamantite arguments before `--` and underlying CLI arguments
+after it:
+
+```shell
+adamantite analyze --strict -- --directory packages/app
+adamantite check src -- --deny-warnings
+adamantite format -- --ignore-path .formatignore
+adamantite monorepo -- --ignore-package package-a
+```
+
+When invoking a package script, the package manager consumes its own `--`, so add a
+second separator for Adamantite:
+
+```shell
+bun run analyze -- -- --directory packages/app
+npm run analyze -- -- --directory packages/app
+```
+
+Passthrough arguments are not supported by `init`, `doctor`, or `update`, because those
+commands do not invoke a single underlying CLI.
 
 ### `adamantite update`
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, test } from "bun:test"
 import { join } from "node:path"
 import type { PackageJson } from "type-fest"
+import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun, { spawn } from "bun"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import { runCli } from "#cli.ts"
+import {
+  createRunnerTestContext,
+  type RunnerTestContext,
+} from "#commands/__tests__/command-test-helpers.ts"
+import { DependencyInstaller } from "#lib/services/dependency-installer.ts"
+import { Prompter } from "#lib/services/prompter.ts"
+
+function runCliWithRunner(args: readonly string[], runner: RunnerTestContext) {
+  return Effect.runPromiseExit(
+    runCli(args, "test").pipe(
+      Effect.provide(
+        Layer.mergeAll(NodeServices.layer, Prompter.layer, runner.layer, DependencyInstaller.layer)
+      )
+    )
+  )
+}
 
 describe("adamantite", () => {
   const cliPath = join(import.meta.dir, "..", "index.ts")
@@ -63,6 +85,44 @@ describe("adamantite", () => {
       expect(stdout).toContain("Help requested")
       expect(stderr).toContain('Unknown subcommand "nope"')
       expect(proc.exitCode).toBe(1)
+    })
+  })
+
+  describe("passthrough arguments", () => {
+    test("forward every argument after the first separator to the selected command", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCliWithRunner(
+        ["analyze", "--strict", "--", "--directory", "packages/app", "--", "--include", "src"],
+        runner
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations).toEqual([
+        {
+          args: [
+            "--production",
+            "--strict",
+            "--directory",
+            "packages/app",
+            "--",
+            "--include",
+            "src",
+          ],
+          command: "knip",
+        },
+      ])
+    })
+
+    test("reject passthrough arguments for commands that do not proxy a CLI", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCliWithRunner(["doctor", "--", "--unknown"], runner)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      const error = Option.getOrThrow(Exit.findErrorOption(exit))
+      expect(error._tag).toBe("PassthroughNotSupported")
+      expect(runner.invocations).toEqual([])
     })
   })
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,81 @@
+import * as Effect from "effect/Effect"
+import * as Command from "effect/unstable/cli/Command"
+import analyzeCommand from "#commands/analyze.ts"
+import checkCommand from "#commands/check.ts"
+import doctorCommand from "#commands/doctor.ts"
+import fixCommand from "#commands/fix.ts"
+import formatCommand from "#commands/format.ts"
+import initCommand from "#commands/init.ts"
+import monorepoCommand from "#commands/monorepo.ts"
+import typecheckCommand from "#commands/typecheck.ts"
+import updateCommand from "#commands/update.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
+import { PassthroughNotSupported } from "#lib/shared/errors.ts"
+
+const passthroughCommands = [
+  analyzeCommand,
+  checkCommand,
+  fixCommand,
+  formatCommand,
+  monorepoCommand,
+  typecheckCommand,
+] as const
+
+const commands = [
+  analyzeCommand,
+  checkCommand,
+  doctorCommand,
+  fixCommand,
+  formatCommand,
+  initCommand,
+  monorepoCommand,
+  typecheckCommand,
+  updateCommand,
+] as const
+const commandNames: ReadonlySet<string> = new Set(commands.map((command) => command.name))
+const passthroughCommandNames: ReadonlySet<string> = new Set(
+  passthroughCommands.map((command) => command.name)
+)
+
+const main = Command.make("adamantite").pipe(
+  Command.withDescription("Opinionated preset package for modern TypeScript applications"),
+  Command.withSubcommands(commands)
+)
+
+interface SplitArguments {
+  readonly command: readonly string[]
+  readonly forwarded: readonly string[]
+}
+
+function splitArguments(args: readonly string[]): SplitArguments {
+  const separatorIndex = args.indexOf("--")
+
+  if (separatorIndex === -1) {
+    return {
+      command: args,
+      forwarded: [],
+    }
+  }
+
+  return {
+    command: args.slice(0, separatorIndex),
+    forwarded: args.slice(separatorIndex + 1),
+  }
+}
+
+export const runCli = Effect.fn("runCli")(function* (args: readonly string[], version: string) {
+  const split = splitArguments(args)
+  const activeCommand = split.command.find((argument) => commandNames.has(argument))
+
+  if (
+    split.forwarded.length > 0 &&
+    activeCommand !== undefined &&
+    !passthroughCommandNames.has(activeCommand)
+  ) {
+    return yield* new PassthroughNotSupported({ command: activeCommand })
+  }
+
+  yield* Command.runWith(main, { version })(split.command).pipe(
+    Effect.provideService(ForwardedArguments, split.forwarded)
+  )
+})

--- a/src/commands/__tests__/analyze.test.ts
+++ b/src/commands/__tests__/analyze.test.ts
@@ -76,6 +76,25 @@ describe("analyze", () => {
     })
   })
 
+  describe("passthrough arguments", () => {
+    test("append arguments after Adamantite-managed flags", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCommandWithRunner(analyzeCommand, ["--strict"], runner, [
+        "--directory",
+        "packages/app",
+      ])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations[0]?.args).toEqual([
+        "--production",
+        "--strict",
+        "--directory",
+        "packages/app",
+      ])
+    })
+  })
+
   describe("error handling", () => {
     test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
       const runner = createRunnerTestContext([1])

--- a/src/commands/__tests__/check.test.ts
+++ b/src/commands/__tests__/check.test.ts
@@ -56,6 +56,23 @@ describe("check", () => {
     })
   })
 
+  describe("passthrough arguments", () => {
+    test("append arguments after file arguments", async () => {
+      await writeFile(join(tempDir, "index.ts"), "export const value = 1\n")
+      const runner = createRunnerTestContext()
+
+      const exit = await runCommandWithRunner(checkCommand, ["index.ts"], runner, [
+        "--deny-warnings",
+      ])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations[0]?.args).toEqual([
+        realpathSync(join(tempDir, "index.ts")),
+        "--deny-warnings",
+      ])
+    })
+  })
+
   describe("error handling", () => {
     test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
       const runner = createRunnerTestContext([2])

--- a/src/commands/__tests__/command-test-helpers.ts
+++ b/src/commands/__tests__/command-test-helpers.ts
@@ -15,6 +15,7 @@ import {
   type DetectedPackageManager,
   DependencyInstaller,
 } from "#lib/services/dependency-installer.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { Prompter } from "#lib/services/prompter.ts"
 import { type FailedToInstallDependency, OperationCancelled } from "#lib/shared/errors.ts"
 
@@ -269,7 +270,8 @@ function makeQuietConsoleLayer() {
 export async function runCommand(
   command: Command.Command.Any,
   args: string[],
-  layers: TestLayer[]
+  layers: TestLayer[],
+  forwardedArguments: readonly string[] = []
 ) {
   let providedLayer = Layer.mergeAll(
     NodeServices.layer,
@@ -283,6 +285,7 @@ export async function runCommand(
 
   return Effect.runPromiseExit(
     Command.runWith(command, { version: "test" })(args).pipe(
+      Effect.provideService(ForwardedArguments, forwardedArguments),
       Effect.provide(providedLayer)
     ) as Effect.Effect<void, unknown>
   )
@@ -291,10 +294,12 @@ export async function runCommand(
 export async function runCommandWithRunner(
   command: Command.Command.Any,
   args: string[],
-  runner: RunnerTestContext
+  runner: RunnerTestContext,
+  forwardedArguments: readonly string[] = []
 ) {
   return Effect.runPromiseExit(
     Command.runWith(command, { version: "test" })(args).pipe(
+      Effect.provideService(ForwardedArguments, forwardedArguments),
       Effect.provide(Layer.mergeAll(NodeServices.layer, runner.layer))
     ) as Effect.Effect<void, unknown>
   )

--- a/src/commands/__tests__/fix.test.ts
+++ b/src/commands/__tests__/fix.test.ts
@@ -87,6 +87,19 @@ describe("fix", () => {
     })
   })
 
+  describe("passthrough arguments", () => {
+    test("append arguments after managed fix flags", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCommandWithRunner(fixCommand, ["--dangerous"], runner, [
+        "--deny-warnings",
+      ])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations[0]?.args).toEqual(["--fix", "--fix-dangerously", "--deny-warnings"])
+    })
+  })
+
   describe("error handling", () => {
     test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
       const runner = createRunnerTestContext([1])

--- a/src/commands/__tests__/format.test.ts
+++ b/src/commands/__tests__/format.test.ts
@@ -62,6 +62,20 @@ describe("format", () => {
     })
   })
 
+  describe("passthrough arguments", () => {
+    test("append arguments after managed formatter arguments", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCommandWithRunner(formatCommand, ["--check"], runner, [
+        "--ignore-path",
+        ".formatignore",
+      ])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations[0]?.args).toEqual(["--check", "--ignore-path", ".formatignore"])
+    })
+  })
+
   describe("error handling", () => {
     test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
       const runner = createRunnerTestContext([1])

--- a/src/commands/__tests__/monorepo.test.ts
+++ b/src/commands/__tests__/monorepo.test.ts
@@ -54,6 +54,24 @@ describe("monorepo", () => {
     })
   })
 
+  describe("passthrough arguments", () => {
+    test("append arguments after managed Sherif flags", async () => {
+      const runner = createRunnerTestContext()
+
+      const exit = await runCommandWithRunner(monorepoCommand, ["--fix"], runner, [
+        "--ignore-package",
+        "package-a",
+      ])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(runner.invocations[0]).toEqual({
+        args: ["--fix", "--ignore-package", "package-a"],
+        command: "sherif",
+        stdin: "inherit",
+      })
+    })
+  })
+
   describe("error handling", () => {
     test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
       const runner = createRunnerTestContext([1])

--- a/src/commands/__tests__/typecheck.test.ts
+++ b/src/commands/__tests__/typecheck.test.ts
@@ -45,6 +45,21 @@ describe("typecheck", () => {
     ])
   })
 
+  test("forward arguments to oxlint", async () => {
+    const prompter = createPrompterTestContext()
+    const runner = createRunnerTestContext()
+
+    const exit = await runCommand(
+      typecheckCommand,
+      [],
+      [prompter.layer, runner.layer],
+      ["--deny-warnings"]
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(runner.invocations[0]?.args).toEqual(["--deny-warnings"])
+  })
+
   test("fail with CommandFailed when the runner returns a non-zero exit code", async () => {
     const prompter = createPrompterTestContext()
     const runner = createRunnerTestContext([1])

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -4,6 +4,7 @@ import * as Flag from "effect/unstable/cli/Flag"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import knip from "#lib/integrations/tooling/knip.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
 const fix = Flag.boolean("fix").pipe(Flag.withDescription("Automatically fix issues"))
@@ -12,8 +13,15 @@ const strict = Flag.boolean("strict").pipe(Flag.withDescription("Enable strict m
 
 export default Command.make("analyze", { fix, strict }).pipe(
   Command.withDescription("Find unused dependencies, exports, and files using knip"),
+  Command.withExamples([
+    {
+      command: "adamantite analyze -- --directory packages/app",
+      description: "Run knip from a specific directory",
+    },
+  ]),
   Command.withHandler(({ fix, strict }) =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const runner = yield* CommandRunner
       const args: string[] = []
 
@@ -24,6 +32,8 @@ export default Command.make("analyze", { fix, strict }).pipe(
       if (strict) {
         args.push("--production", "--strict")
       }
+
+      args.push(...forwardedArguments)
 
       const exitCode = yield* runner.run({
         args,

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -4,6 +4,7 @@ import * as Command from "effect/unstable/cli/Command"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
 const files = Argument.file("files", { mustExist: true }).pipe(
@@ -15,9 +16,10 @@ export default Command.make("check", { files }).pipe(
   Command.withDescription("Find issues and type errors in code using oxlint"),
   Command.withHandler(({ files }) =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const runner = yield* CommandRunner
       const exitCode = yield* runner.run({
-        args: [...files],
+        args: [...files, ...forwardedArguments],
         command: oxlint.name,
       })
 

--- a/src/commands/fix.ts
+++ b/src/commands/fix.ts
@@ -5,6 +5,7 @@ import * as Flag from "effect/unstable/cli/Flag"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
 const files = Argument.file("files", { mustExist: true }).pipe(
@@ -24,6 +25,7 @@ export default Command.make("fix", { all, dangerous, files, suggested }).pipe(
   Command.withDescription("Fix issues in code using oxlint"),
   Command.withHandler(({ all, dangerous, files, suggested }) =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const runner = yield* CommandRunner
       const args = new Set<string>(["--fix"])
 
@@ -40,7 +42,7 @@ export default Command.make("fix", { all, dangerous, files, suggested }).pipe(
       }
 
       const exitCode = yield* runner.run({
-        args: [...args],
+        args: [...args, ...forwardedArguments],
         command: oxlint.name,
       })
 

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -5,6 +5,7 @@ import * as Flag from "effect/unstable/cli/Flag"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import oxfmt from "#lib/integrations/tooling/oxfmt.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
 const files = Argument.file("files", { mustExist: true }).pipe(
@@ -20,6 +21,7 @@ export default Command.make("format", { check, files }).pipe(
   Command.withDescription("Format files using oxfmt"),
   Command.withHandler(({ check, files }) =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const runner = yield* CommandRunner
       const args: string[] = []
 
@@ -27,7 +29,7 @@ export default Command.make("format", { check, files }).pipe(
         args.push("--check")
       }
 
-      args.push(...files)
+      args.push(...files, ...forwardedArguments)
 
       const exitCode = yield* runner.run({
         args,

--- a/src/commands/monorepo.ts
+++ b/src/commands/monorepo.ts
@@ -4,6 +4,7 @@ import * as Flag from "effect/unstable/cli/Flag"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import sherif from "#lib/integrations/tooling/sherif.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
 const fix = Flag.boolean("fix").pipe(Flag.withDescription("Automatically fix issues"))
@@ -12,8 +13,9 @@ export default Command.make("monorepo", { fix }).pipe(
   Command.withDescription("Find and fix monorepo-specific issues using Sherif"),
   Command.withHandler(({ fix }) =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const runner = yield* CommandRunner
-      const args = fix ? ["--fix"] : []
+      const args = fix ? ["--fix", ...forwardedArguments] : [...forwardedArguments]
       const exitCode = yield* runner.run({
         args,
         command: sherif.name,

--- a/src/commands/typecheck.ts
+++ b/src/commands/typecheck.ts
@@ -3,6 +3,7 @@ import * as Command from "effect/unstable/cli/Command"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
+import { ForwardedArguments } from "#lib/services/forwarded-arguments.ts"
 import { Prompter } from "#lib/services/prompter.ts"
 import { CommandFailed } from "#lib/shared/errors.ts"
 
@@ -10,13 +11,14 @@ export default Command.make("typecheck").pipe(
   Command.withDescription("Deprecated alias for `check`"),
   Command.withHandler(() =>
     Effect.gen(function* () {
+      const forwardedArguments = yield* ForwardedArguments
       const prompter = yield* Prompter
       const runner = yield* CommandRunner
 
       yield* prompter.log.warning("Deprecated. Use `adamantite check` for typechecking.")
 
       const exitCode = yield* runner.run({
-        args: [],
+        args: [...forwardedArguments],
         command: oxlint.name,
       })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,40 +4,22 @@ import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Layer from "effect/Layer"
 import * as Runtime from "effect/Runtime"
-import * as Command from "effect/unstable/cli/Command"
+import * as Stdio from "effect/Stdio"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
-import analyzeCommand from "#commands/analyze.ts"
-import checkCommand from "#commands/check.ts"
-import doctorCommand from "#commands/doctor.ts"
-import fixCommand from "#commands/fix.ts"
-import formatCommand from "#commands/format.ts"
-import initCommand from "#commands/init.ts"
-import monorepoCommand from "#commands/monorepo.ts"
-import typecheckCommand from "#commands/typecheck.ts"
-import updateCommand from "#commands/update.ts"
+import { runCli } from "#cli.ts"
 import { CommandRunner } from "#lib/services/command-runner.ts"
 import { DependencyInstaller } from "#lib/services/dependency-installer.ts"
 import { Prompter } from "#lib/services/prompter.ts"
 import { getPackageVersion } from "#lib/shared/version.macro.ts" with { type: "macro" }
 
-const main = Command.make("adamantite").pipe(
-  Command.withDescription("Opinionated preset package for modern TypeScript applications"),
-  Command.withSubcommands([
-    analyzeCommand,
-    checkCommand,
-    doctorCommand,
-    fixCommand,
-    formatCommand,
-    initCommand,
-    monorepoCommand,
-    typecheckCommand,
-    updateCommand,
-  ])
-)
-
 const version = getPackageVersion()
 
-const program = Command.run(main, { version }).pipe(
+const program = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio
+  const args = yield* stdio.args
+
+  yield* runCli(args, version)
+}).pipe(
   Effect.as(0),
   Effect.catchTag("CommandFailed", (error) => Effect.succeed(error.exitCode)),
   Effect.catch((error) =>

--- a/src/lib/services/forwarded-arguments.ts
+++ b/src/lib/services/forwarded-arguments.ts
@@ -1,0 +1,8 @@
+import * as Context from "effect/Context"
+
+export const ForwardedArguments = Context.Reference<readonly string[]>(
+  "adamantite/ForwardedArguments",
+  {
+    defaultValue: () => [],
+  }
+)

--- a/src/lib/shared/errors.ts
+++ b/src/lib/shared/errors.ts
@@ -185,6 +185,14 @@ export class OperationCancelled extends Data.TaggedError("OperationCancelled")<{
   }
 }
 
+export class PassthroughNotSupported extends Data.TaggedError("PassthroughNotSupported")<{
+  command: string
+}> {
+  override get message() {
+    return `Command \`adamantite ${this.command}\` does not invoke a single underlying CLI and cannot accept passthrough arguments.`
+  }
+}
+
 export class UnknownScript extends Data.TaggedError("UnknownScript")<{ script: string }> {
   override get message() {
     return `Unknown script: \`${this.script}\`.`


### PR DESCRIPTION
Arguments placed after `--` are now forwarded to the underlying CLI tool for commands that wrap Knip, Oxlint, Oxfmt, or Sherif (`analyze`, `check`, `fix`, `format`, `monorepo`, and `typecheck`). The separator splits Adamantite's own arguments from those passed through to the tool:

```shell
adamantite analyze --strict -- --directory packages/app
adamantite check src -- --deny-warnings
adamantite format -- --ignore-path .formatignore
adamantite monorepo -- --ignore-package package-a
```

When invoking through a package manager script, a second `--` is required because the package manager consumes the first one:

```shell
bun run analyze -- -- --directory packages/app
```

Commands that do not proxy a single CLI (`init`, `doctor`, and `update`) reject passthrough arguments with a `PassthroughNotSupported` error.

A new `ForwardedArguments` context reference carries the parsed passthrough arguments through the effect pipeline, defaulting to an empty array so existing commands require no changes to their signatures. Argument splitting is handled in a new `cli.ts` module that extracts the portion before and after the first `--` separator before delegating to the command router.