### PR TITLE
Add `adamantite` agent skill and TanStack Intent CI workflow for skill validation and coverage review

### DIFF
--- a/.changeset/proud-skills-teach.md
+++ b/.changeset/proud-skills-teach.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Ship an `adamantite` agent skill (`skills/adamantite/SKILL.md`) in the npm package. The skill teaches coding agents how to initialize, check, repair, and update Adamantite in a project, and is discoverable through TanStack Intent (`intent list` / `intent load`).

--- a/.github/workflows/check-skills.yml
+++ b/.github/workflows/check-skills.yml
@@ -1,0 +1,107 @@
+# check-skills.yml — Drop this into your library repo's .github/workflows/
+#
+# Validates intent skills on PRs. After a release or manual run, opens or
+# updates one review PR when existing skills, artifact coverage, or workspace
+# package coverage need review.
+#
+# Triggers: pull requests touching skills/artifacts, new release published, or
+# manual workflow_dispatch.
+#
+# intent-workflow-version: 3
+#
+# Template variables (replaced by `intent setup`):
+#   adamantite — e.g. @tanstack/query or my-workspace workspace
+
+name: Check Skills
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "**/skills/**"
+      - "_artifacts/**"
+      - "**/_artifacts/**"
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate intent skills
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Install intent
+        run: npm install -g @tanstack/intent@0.3.6
+
+      - name: Validate skills
+        run: intent validate --github-summary
+
+  review:
+    name: Check intent skill coverage
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Install intent
+        run: npm install -g @tanstack/intent@0.3.6
+
+      - name: Check skills
+        id: stale
+        run: |
+          intent stale --github-review --package-label "adamantite"
+
+      - name: Open or update review PR
+        if: steps.stale.outputs.has_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.release.tag_name || 'manual' }}"
+          BRANCH="skills/review-${VERSION}"
+          BASE_BRANCH="${{ github.event.repository.default_branch }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$BRANCH" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            git commit --allow-empty -m "chore: review intent skills for ${VERSION}"
+            git push origin "$BRANCH"
+          fi
+
+          PR_URL="$(gh pr list --head "$BRANCH" --json url --jq '.[0].url')"
+          if [ -n "$PR_URL" ]; then
+            gh pr edit "$PR_URL" --body-file pr-body.md
+          else
+            gh pr create \
+              --title "Review intent skills (${VERSION})" \
+              --body-file pr-body.md \
+              --head "$BRANCH" \
+              --base "$BASE_BRANCH"
+          fi

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "0.7.0",
         "@changesets/cli": "2.31.1",
+        "@tanstack/intent": "0.3.6",
         "@types/bun": "1.3.14",
         "@types/figlet": "1.7.0",
         "bunup": "0.16.32",
@@ -363,6 +364,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@tanstack/intent": ["@tanstack/intent@0.3.6", "", { "dependencies": { "cac": "^6.7.14", "jsonc-parser": "^3.3.1", "semver": "^7.8.4", "std-env": "^4.1.0", "yaml": "2.9.0" }, "bin": { "intent": "dist/cli.mjs" } }, "sha512-ylew/4T3layUXSfE/SDGUSAi1B3U/wuoNUE0adC3j/s6wzX7omV6e6hAv0WyMC52Inren8kqvwpHj+G/ZBbQHQ=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -428,6 +431,8 @@
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bunup": ["bunup@0.16.32", "", { "dependencies": { "@bunup/dts": "^0.14.53", "@bunup/shared": "0.16.31", "chokidar": "^5.0.0", "coffi": "^0.1.37", "lightningcss": "^1.32.0", "picocolors": "^1.1.1", "tinyexec": "^1.2.4", "tree-kill": "^1.2.2", "zlye": "^0.4.4" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"], "bin": { "bunup": "dist/cli/index.js" } }, "sha512-w7RpjGl/AlJMRs0EovFJ0ddF5BOnxZlgDt5Q5xamz/WPd74BqJSetaeCQPDBzvSlOe0gZY90q6lFmjip/aKv2w=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
@@ -699,7 +704,7 @@
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -761,6 +766,8 @@
 
     "@bunup/dts/oxc-resolver": ["oxc-resolver@11.16.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.16.2", "@oxc-resolver/binding-android-arm64": "11.16.2", "@oxc-resolver/binding-darwin-arm64": "11.16.2", "@oxc-resolver/binding-darwin-x64": "11.16.2", "@oxc-resolver/binding-freebsd-x64": "11.16.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.16.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.16.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.16.2", "@oxc-resolver/binding-linux-arm64-musl": "11.16.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.16.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.16.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.16.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.16.2", "@oxc-resolver/binding-linux-x64-gnu": "11.16.2", "@oxc-resolver/binding-linux-x64-musl": "11.16.2", "@oxc-resolver/binding-openharmony-arm64": "11.16.2", "@oxc-resolver/binding-wasm32-wasi": "11.16.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.16.2", "@oxc-resolver/binding-win32-ia32-msvc": "11.16.2", "@oxc-resolver/binding-win32-x64-msvc": "11.16.2" } }, "sha512-Uy76u47vwhhF7VAmVY61Srn+ouiOobf45MU9vGct9GD2ARy6hKoqEElyHDB0L+4JOM6VLuZ431KiLwyjI/A21g=="],
 
+    "@bunup/dts/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -772,6 +779,8 @@
     "@oxc-minify/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tanstack/intent/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "knip/oxc-parser": ["oxc-parser@0.142.0", "", { "dependencies": { "@oxc-project/types": "^0.142.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.142.0", "@oxc-parser/binding-android-arm64": "0.142.0", "@oxc-parser/binding-darwin-arm64": "0.142.0", "@oxc-parser/binding-darwin-x64": "0.142.0", "@oxc-parser/binding-freebsd-x64": "0.142.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0", "@oxc-parser/binding-linux-arm64-gnu": "0.142.0", "@oxc-parser/binding-linux-arm64-musl": "0.142.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0", "@oxc-parser/binding-linux-riscv64-musl": "0.142.0", "@oxc-parser/binding-linux-s390x-gnu": "0.142.0", "@oxc-parser/binding-linux-x64-gnu": "0.142.0", "@oxc-parser/binding-linux-x64-musl": "0.142.0", "@oxc-parser/binding-openharmony-arm64": "0.142.0", "@oxc-parser/binding-wasm32-wasi": "0.142.0", "@oxc-parser/binding-win32-arm64-msvc": "0.142.0", "@oxc-parser/binding-win32-ia32-msvc": "0.142.0", "@oxc-parser/binding-win32-x64-msvc": "0.142.0" } }, "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "oxfmt",
     "oxlint",
     "preset",
+    "tanstack-intent",
     "typescript"
   ],
   "homepage": "https://github.com/adelrodriguez/adamantite",
@@ -27,7 +28,9 @@
   "files": [
     "bin",
     "dist",
-    "presets"
+    "presets",
+    "skills",
+    "!skills/_artifacts"
   ],
   "type": "module",
   "main": "dist/presets/lint/core.js",
@@ -81,6 +84,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.1",
+    "@tanstack/intent": "0.3.6",
     "@types/bun": "1.3.14",
     "@types/figlet": "1.7.0",
     "bunup": "0.16.32",

--- a/skills/adamantite/SKILL.md
+++ b/skills/adamantite/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: adamantite
+description: Configures and maintains Adamantite linting, formatting, type-safety, analysis, editor, and CI tooling in TypeScript projects. Use when initializing Adamantite, running its checks, repairing a broken or drifted setup, or updating and migrating an existing installation.
+metadata:
+  type: core
+  library: adamantite
+  library_version: "0.34.0"
+sources:
+  - "adelrodriguez/adamantite:src/cli.ts"
+  - "adelrodriguez/adamantite:src/commands/*.ts"
+---
+
+# Adamantite
+
+Adamantite is an opinionated preset package and CLI for modern TypeScript projects. Run
+commands from the target project's root and use its detected package manager.
+
+## Quick start
+
+For a human-driven setup, run `npx adamantite init`. For an agent, prefer explicit
+non-interactive setup. Setup flags require `--non-interactive`, and at least one
+`--script` is required:
+
+```shell
+npx adamantite init --non-interactive --script check --script fix --script format --typescript --agents
+```
+
+Repeat `--script`, `--preset`, and `--editor` for multiple values. Available values are:
+
+- Scripts: `check`, `fix`, `format`, `analyze`, `check:monorepo`, `fix:monorepo`
+- Presets: `react`, `nextjs`, `vue`, `jest`, `vitest`, `node`; editors: `vscode`, `zed`
+- Optional flags: `--typescript`, `--install-extensions`, `--github-actions`, `--agents`
+
+Only select options supported by the project. Presets and TypeScript require `check` or
+`fix`; extension installation requires an editor; monorepo scripts require a detected
+monorepo; `--github-actions` requires a CI-compatible script and a supported package
+manager (bun, deno, npm, pnpm, or yarn). Omitted boolean flags are disabled.
+
+## Daily workflow
+
+Use the scripts written by `init` when available. Otherwise invoke the CLI directly:
+
+```shell
+adamantite check
+adamantite fix
+adamantite format
+adamantite format --check
+adamantite analyze
+adamantite monorepo
+```
+
+- Use `check` for read-only lint and type-error validation.
+- Use `fix` for automatic oxlint fixes. Add `--suggested`, `--dangerous`, or `--all` only
+  with explicit permission after reviewing their impact.
+- Use `format` to write formatting changes and `format --check` for read-only CI checks.
+- Use `analyze` for unused dependencies, exports, and files. `analyze --fix` may remove
+  files, so inspect findings before using it.
+- Use `monorepo` to inspect workspace dependency consistency and `monorepo --fix` to fix it.
+
+To pass arguments to Knip, Oxlint, Oxfmt, or Sherif, place them after `--`:
+
+```shell
+adamantite check src -- --deny-warnings
+bun run analyze -- -- --directory packages/app
+```
+
+## Diagnose and repair
+
+Start with the read-only assessment:
+
+```shell
+adamantite doctor
+```
+
+If it reports safe automatic actions, apply them and reassess:
+
+```shell
+adamantite doctor --fix
+adamantite doctor
+```
+
+`doctor --fix` is the mutating repair dispatcher. It installs or updates managed packages,
+creates or updates supported configs, and runs known migrations. Manual-fix findings remain
+report-only; follow their instructions instead of overwriting custom configuration.
+
+## Update and migrate
+
+For an existing installation, run:
+
+```shell
+adamantite update
+adamantite doctor --fix
+adamantite doctor
+```
+
+`update` runs applicable legacy migrations and updates Adamantite-managed dependencies. It
+may leave supported config creation, config updates, or manual work to `doctor --fix`.
+Migrations restore affected files if they fail; still review the resulting diff and run the
+project's tests after any mutation.
+
+## Decision guide
+
+- New target project: `init`, then run the configured checks.
+- Suspected drift or broken setup: `doctor`, then `doctor --fix` if appropriate.
+- Existing project upgrading Adamantite: `update`, then the doctor sequence.
+- Code-quality failure: choose `check`, `format --check`, `analyze`, or `monorepo` based on
+  the failing subsystem; do not reinitialize the project.
+- Unknown option or behavior: run `adamantite <command> --help` before guessing.


### PR DESCRIPTION
This PR adds TanStack Intent skill support to the Adamantite package, making it discoverable and usable by coding agents via `intent list` / `intent load`.

## What's included

**`skills/adamantite/SKILL.md`** — A new agent skill that teaches coding agents how to work with Adamantite, covering:
- Non-interactive initialization with `adamantite init`
- Daily workflow commands (`check`, `fix`, `format`, `analyze`, `monorepo`)
- Diagnosing and repairing broken or drifted setups via `adamantite doctor`
- Updating and migrating existing installations via `adamantite update`
- A decision guide for choosing the right command in each scenario

**`.github/workflows/check-skills.yml`** — A CI workflow that:
- Validates skills on PRs that touch `skills/**` or `_artifacts/**`
- After releases or manual runs, opens or updates a review PR when skill coverage needs attention

**Package changes:**
- `skills/` is added to the npm `files` list (excluding `skills/_artifacts`) so the skill ships with the package
- `@tanstack/intent` is added as a dev dependency for local skill validation