### PR TITLE
Bump GitHub Actions versions, make Zed setup idempotent, and replace `isJsonObject` with `Predicate.isObject`

### DIFF
--- a/.changeset/clean-docs.md
+++ b/.changeset/clean-docs.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Restructure and update the product documentation for the current CLI, presets, setup lifecycle, and supported runtime requirements.

--- a/.changeset/tidy-editor-ci-init.md
+++ b/.changeset/tidy-editor-ci-init.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Keep generated GitHub Actions workflows aligned with the repository's current action versions and make repeated Zed editor setup idempotent.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dependencies (bun install)
 node_modules
-.repos/effect
+.packref/packages/
+.packref/.packref-lock-*.tmp
 
 # output
 out

--- a/.packref/packref-lock.json
+++ b/.packref/packref-lock.json
@@ -1,0 +1,26 @@
+{
+  "packages": [
+    {
+      "name": "effect",
+      "registry": "npm",
+      "source": {
+        "directory": "packages/effect",
+        "host": "github.com",
+        "type": "repository",
+        "url": "https://github.com/Effect-TS/effect"
+      },
+      "tracking": "dependency",
+      "version": "4.0.0-beta.102"
+    },
+    {
+      "name": "oxc-parser",
+      "registry": "npm",
+      "source": {
+        "type": "tarball",
+        "url": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz"
+      },
+      "tracking": "dependency",
+      "version": "0.143.0"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,100 +1,75 @@
 # AGENTS.md
 
-This project was built with [`pastry`](https://github.com/adelrodriguez/pastry) template.
+Use ASD-STE100 Simplified Technical English for all communication.
+
+Before you explore or change code, read `CONTEXT.md` and the relevant parts of
+`docs/architecture.md`. Use the project's domain language.
 
 ## Agent skills
 
+### Source references
+
+When a skill requires a local dependency source checkout, use Packref. Add the package
+with `bunx packref add <package>` and read its version-locked source under
+`.packref/packages/`.
+
 ### Issue tracker
 
-Issues and PRDs are tracked as GitHub issues at `adelrodriguez/adamantite` (via the `gh` CLI). See `docs/agents/issue-tracker.md`.
+Issues and PRDs are GitHub issues at `adelrodriguez/adamantite`. See
+`docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-Default triage vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+Use the default five-role triage vocabulary. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 
-Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Use the single-context domain-doc layout. See `docs/agents/domain.md`.
 
-## Quality Control
+### Changesets
 
-- We use `adamantite` for linting, formatting and type checking.
-- Always run `bun run format` after editing files.
-- After making changes, run `bun run check` and `bun run test` to ensure the code is still valid.
-- After installing or removing dependencies, run `bun run analyze` to ensure we are not using any dependencies that are not needed.
+Use Changesets for versioning and changelog management. See
+`docs/agents/changesets.md`.
 
-## Changesets
+## Repository rules
 
-- We use `changesets` for versioning and changelog management.
-- Create a changeset only for changes that affect users of the published package, such as CLI behavior, presets, package exports, dependencies used at runtime, or documentation shipped to users.
-- Do not add a changeset for internal-only changes, such as tests, CI, release tooling, contributor docs, or repository maintenance that does not affect package users.
-- Never make a major version bump unless the user requests it.
-- If a breaking change is being made, and we are on v1.0.0 or higher, alert the user.
+- Use Bun for package management and scripts.
+- Run `bun run test`, `bun run check`, `bun run fix`, and `bun run format` after edits.
+- Run `bun run analyze` after dependency, import, or export changes.
+- Prefer function declarations for standalone functions. Keep arrow functions for
+  callbacks, object methods, and functions that directly return an Effect chain.
+- Format suppressions as `@ts-expect-error - reason`. Prefer this form to casts that hide
+  known third-party type mismatches.
+- Keep integration modules limited to their default integration export.
+  `src/lib/integrations/base.ts` is the shared infrastructure exception.
+- Keep reusable integration behavior in `src/lib/workspace` or `src/lib/shared`.
+- Keep one-time transition behavior in `src/lib/migrations`.
+- Keep `init` independent from migration orchestration.
+- Keep `assess` read-only. `doctor --fix` is the mutating assessment dispatcher, and
+  manual fixes are report-only.
+- Migrations may call integrations. Integrations must not call migrations.
+- Keep tooling integration versions aligned with the corresponding versions in
+  `package.json`.
 
-## Project Overview
+<!-- PACKREF:START -->
 
-For what Adamantite is, its domain vocabulary, the integration lifecycle verbs, and the
-codebase map, see `CONTEXT.md`.
+## Packref
 
-## Development Commands
+Packref provides local copies of dependency source code so you can inspect the exact implementation used by this project.
 
-Use Bun for all package management and script execution:
+- Source references are stored in `.packref/packages/<registry>/<package>/<version>/` for unscoped packages and `.packref/packages/<registry>/<scope>/<package>/<version>/` for scoped packages — browse these directories to read dependency internals
+- `.packref/packref-lock.json` is shared and should be committed; `.packref/packages/` is developer-local and git-ignored
+- Run `packref install` after cloning when locked references are missing; install restores locked references exactly and does not install runtime dependencies
+- Available commands:
+  - `packref add [package]` — select manifest dependencies or fetch a named package (e.g. `packref add react`, `packref add hono@4.2.0`, `packref add @effect/cli`)
+  - `packref remove [package]` — select or name package references to remove
+  - `packref install` — materialize every reference already recorded in the committed lockfile
+  - `packref sync` — update dependency-tracked lock entries to match current `package.json` dependency versions
+  - `packref list` — show all referenced packages
+  - `packref prune` — remove unused entries from the global store
+  - `packref clean` — remove all project-local references
+  - `packref clean --global` — wipe all global store entries
+- Use Packref when you need to understand how a dependency works internally — read the source in `.packref/` instead of guessing or searching the web
+- Multiple versions of the same package can coexist; check `.packref/packref-lock.json` for the full list
 
-- **Install dependencies**: `bun install`
-- **Build CLI**: `bun run build` (uses bunup to bundle `src/index.ts` → `dist/`)
-- **Run tests**: `bun test` or `bun run test:watch` for watch mode
-- **Code checking**: `bun run check` (checks for issues and type errors)
-- **Code fixing**: `bun run fix` (auto-fixes issues and formats code)
-- **Code formatting**: `bun run format` (formats code with oxfmt)
-
-## Code Quality Workflow
-
-After editing files, always run:
-
-1. `bun run test` - Run tests to ensure everything works
-2. `bun run check` - Check for linting issues and type errors
-3. `bun run fix` - Auto-fix issues and format code
-4. `bun run format` - Format code explicitly (run after editing various files)
-
-Make sure to always run format after editing files, including creating documentation like changesets and README.md.
-
-## Release Workflow
-
-This project uses changesets for version management:
-
-1. **Create changeset when user-facing**: `bunx changeset` (interactive prompt for version bump)
-2. **Version locally**: `bun run version` (bumps package.json and updates CHANGELOG)
-3. **Publish**: Push to main → CI passes → auto-publishes to npm
-
-## Code Style
-
-- Prefer function declarations over arrow functions for standalone functions (e.g. `function getImportName(...)` instead of `const getImportName = (...) =>`).
-- Keep arrow functions when returning an Effect chain (e.g. `const foo = (args) => Effect.gen(...)`), or when they are callbacks, object methods, or otherwise more pleasant as arrows.
-- Format TypeScript suppression comments as `@ts-expect-error - reason` so they fail loudly if the underlying type issue is fixed.
-- Prefer `@ts-expect-error - reason` over casts like `as never` when suppressing known third-party type mismatches, so upstream type fixes become visible.
-
-## Architecture
-
-For domain definitions (integration, migration, lifecycle verbs, managed script), the
-codebase map, the build pipeline, and the preset files, see `CONTEXT.md`. The rules below
-are the guardrails to follow when working in those areas.
-
-### Integration Boundaries
-
-- Integration modules should only export the integration itself (default export). Keep extra helpers out of those files. `src/lib/integrations/base.ts` is the shared infrastructure exception.
-- If integration-related logic needs to be reused, move it to a nearby non-integration module such as `src/lib/workspace/**` or `src/lib/shared/**` instead of adding named exports to an integration file.
-- Keep one-off transition logic in `src/lib/migrations/**`. Do not move migration behavior into integration files just to simplify command wiring.
-- Keep `init` simple. It should not import migration helpers or perform migration-specific orchestration.
-- When `init` finds existing setup that it intentionally leaves alone, prefer warning and follow-up guidance over mutation. Point users to `adamantite doctor` / `adamantite doctor --fix` for verification and safe local fixes.
-
-### Integration Lifecycle Invariants
-
-- `assess` is read-only: it must not mutate files or call migrations.
-- `doctor --fix` is the only mutating dispatcher; `manual_fix` is report-only.
-- Migrations may call integrations to reach the latest supported shape. Integrations must not call migrations.
-
-### Dependency Management
-
-When a tooling dependency's version in `package.json` is higher than the version recorded
-in its `src/lib/integrations/tooling/` integration object, update the integration object
-to match.
+<!-- PACKREF:END -->

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,94 +1,73 @@
-# Context
+# Adamantite
 
-Domain language and orientation for Adamantite. Read this before exploring or changing
-code so you use the project's own terms instead of inventing synonyms. This file
-describes _what things mean_; standing rules and commands live in `AGENTS.md`.
+Adamantite is an opinionated preset package and CLI for modern TypeScript projects. It
+applies and maintains code-quality tooling in a target project.
 
-## What Adamantite is
+## Language
 
-Adamantite is an opinionated **preset** package for modern TypeScript applications. It
-ships configuration and a CLI that applies and maintains that configuration in a target
-project. It provides:
+**Preset**:
+Published configuration that a target project consumes for linting, formatting, analysis,
+or TypeScript.
+_Avoid_: Plugin, template
 
-- **oxlint configuration** (`presets/lint/*.ts`) — modular linting rules (core, React, Next.js)
-- **oxfmt configuration** (`presets/format.ts`) — code formatting configuration
-- **TypeScript preset** (`presets/tsconfig.json`) — strict TypeScript configuration
-- **CLI tool** — commands to run oxlint linting and oxfmt formatting via the `adamantite` command
+**Target project**:
+The project that Adamantite configures or checks.
+_Avoid_: Adamantite repository, consumer repository
 
-## Glossary
+**Managed integration**:
+An adapter for a tool, editor, workspace feature, or CI provider whose supported state
+Adamantite can detect and maintain.
+_Avoid_: Plugin, preset
 
-- **Preset** — the shipped configuration under `presets/` (lint, format, tsconfig) that
-  a target project consumes.
-- **Target project** — the user's repository that Adamantite is configuring. Distinct
-  from _this_ repository (the Adamantite source itself).
-- **Integration** — an adapter under `src/lib/integrations/**` for a tool, editor, or CI
-  system. Each integration module exports only the integration itself (default export);
-  `src/lib/integrations/base.ts` is the shared-infrastructure exception.
-- **Migration** — one-off transition logic under `src/lib/migrations/**` that handles
-  upgrades falling outside an integration's normal lifecycle (legacy formats, legacy
-  scripts, one-off upgrades).
-- **Managed script** — a `package.json` script entry Adamantite owns. Types and helpers
-  (`Script`, `MANAGED_SCRIPT_COMMANDS`, `getManagedScripts`) live in
-  `src/lib/workspace/package-json.ts`.
+**Tooling integration**:
+A managed integration for a package and its configuration, such as Oxlint, Oxfmt, Knip,
+Sherif, or Tsgolint.
+_Avoid_: Dependency adapter
 
-### Integration lifecycle verbs
+**Migration**:
+A one-time transition for legacy state that falls outside the normal managed integration
+lifecycle.
+_Avoid_: Update, fix
 
-Every integration is described by these operations:
+**Managed script**:
+A `package.json` script whose command is owned by Adamantite.
+_Avoid_: User script, package command
 
-- **`detect`** — inspects whether the integration is present and, for tooling integrations,
-  which config format is active and which legacy configs coexist with it.
-- **`create`** — writes the latest supported config from scratch.
-- **`update`** — safely rewrites an existing latest-format config into the latest
-  supported shape.
-- **`migrations`** — handle transitions that fall outside `detect` / `create` /
-  `update`, such as legacy formats, legacy scripts, or one-off upgrades.
-- **`assess`** — read-only. Classifies package drift, missing config, supported config
-  updates, manual follow-up work, and known migrations. It does not mutate files or call
-  migrations.
-- **`doctor` / `doctor --fix`** — `doctor --fix` dispatches `create_config` through
-  `create`, `update_config` through `update`, and `run_migration` through the migration
-  system. `manual_fix` is report-only.
+**Assessment**:
+A read-only classification of the current state of a managed integration and the action,
+if any, needed to reach the latest supported state.
+_Avoid_: Check result, diagnostic
 
-Integrations are defined through a single `defineIntegration` boundary. Its `kind`
-discriminant establishes the required capabilities: tooling integrations provide a package
-version and read-only assessment, while editor, workspace, and CI integrations provide
-`detect` / `create` / `update`. Additional capabilities remain available on the exact inferred
-integration type.
+**Manual fix**:
+An assessment that Adamantite reports but does not apply because automatic mutation could
+overwrite unsupported or custom project state.
+_Avoid_: Automatic fix
 
-## Codebase map
+## Integration lifecycle
 
-### CLI structure (`src/`)
+**Detect**:
+Inspect whether a managed integration is present and identify its supported or legacy
+configuration state.
+_Avoid_: Assess, create
 
-- **`index.ts`** — main CLI entry point using yargs
-- **`commands/`** — command implementations:
-  - `fix.ts` — runs oxlint to fix issues
-  - `check.ts` — runs oxlint to check for issues
-  - `format.ts` — runs oxfmt for code formatting
-  - `init.ts` — initializes Adamantite configuration
-  - `monorepo.ts` — runs monorepo-specific checks (use `--fix` to auto-fix issues)
-  - `update.ts` — updates Adamantite configuration
-- **`lib/`** — internal library code grouped by concern:
-  - `services/` — Effect services used by commands
-  - `integrations/` — adapters for tooling, editors, and CI
-  - `workspace/` — logic that operates on the target project on disk
-  - `shared/` — cross-cutting utilities and error types
-- **`version.ts`** — package version detection
+**Create**:
+Write the latest supported configuration when it is missing.
+_Avoid_: Migrate, update
 
-### Preset / configuration files
+**Update**:
+Rewrite an existing supported configuration into the latest supported shape.
+_Avoid_: Migration, dependency update
 
-- **`presets/lint/core.ts`** — core linting rules for all TypeScript/JavaScript projects
-- **`presets/format.ts`** — code formatting configuration
-- **`presets/tsconfig.json`** — reusable TypeScript configuration
+**Assess**:
+Classify package drift, missing configuration, supported configuration updates, manual
+work, and known migrations without changing the target project.
+_Avoid_: Doctor fix, migration
 
-### Build pipeline
+**Doctor**:
+Report assessments for Adamantite-managed integrations.
+_Avoid_: Check, update
 
-- **bunup** (`bunup.config.ts`) bundles the CLI to `dist/index.js` with minification.
-- Entry point: `src/index.ts` → output: `dist/index.js` (executable via the `adamantite`
-  command).
-
-### Dependencies on tooling
-
-Adamantite depends on multiple packages to perform its tasks. These dependencies are
-defined inside the `src/lib/integrations/tooling/` directory. Each package has a version
-property used to determine the version to install; it should match the version in
-`package.json`.
+**Doctor fix**:
+Apply safe assessment actions through integration creation, integration updates, package
+installation, and migrations. Manual fixes remain report-only.
+_Avoid_: Update command, fix command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,247 +1,100 @@
 # Contributing to Adamantite
 
-Thanks for your interest in contributing to Adamantite! This guide will help you get started with contributing to the project.
+Thank you for contributing to Adamantite.
 
-## 🚀 Getting Started
+## Requirements
 
-### Prerequisites
+- [Bun](https://bun.sh) 1.3.14 or later.
+- [Node.js](https://nodejs.org) 24 or later for Node.js compatibility checks.
+- [Git](https://git-scm.com).
 
-- [Bun](https://bun.sh/) 1.2.20 or later
-- [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) 18+ (for compatibility testing)
+## Set up the repository
 
-### Setting Up Your Development Environment
+1. Fork and clone the repository.
+2. Install dependencies:
 
-1. Fork the repository on GitHub
-2. Clone your fork locally:
-
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/adamantite.git
-   cd adamantite
-   ```
-
-3. Install dependencies:
-
-   ```bash
+   ```sh
    bun install
    ```
 
-4. Create a new branch for your feature or fix:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+3. Create a branch for the change.
 
-## 🛠️ Development Workflow
+Read [CONTEXT.md](CONTEXT.md) before you change domain behavior. Use
+[docs/architecture.md](docs/architecture.md) to find the relevant module boundary.
 
-### Available Scripts
+## Development commands
 
-- `bun run build` - Build the CLI tool
-- `bun run dev` - Build in watch mode for development
-- `bun test` - Run all tests
-- `bun run test:watch` - Run tests in watch mode
-- `bun run check` - Check for code issues and type errors using oxlint
-- `bun run fix` - Auto-fix code issues using oxlint
-- `bun run format` - Format code using oxfmt
-
-### Making Changes
-
-1. **Before coding**: Run tests to ensure everything works:
-
-   ```bash
-   bun test
-   ```
-
-2. **During development**: Use watch mode for continuous feedback:
-
-   ```bash
-   bun run dev        # For building
-   bun run test:watch # For testing
-   ```
-
-3. **Before committing**: Ensure code quality:
-   ```bash
-   bun run check
-   bun run fix
-   bun run format
-   bun test
-   ```
-
-## 🧪 Testing
-
-### Running Tests
-
-```bash
-# Run all tests
-bun test
-
-# Run tests in watch mode
-bun run test:watch
-
-# Run specific test file
-bun test src/__tests__/index.test.ts
+```sh
+bun run build       # Bundle the CLI and published presets into dist.
+bun run dev         # Rebuild when source files change.
+bun run test        # Run the Bun test suite.
+bun run test:watch  # Run tests when files change.
+bun run check       # Check lint rules and TypeScript types.
+bun run fix         # Apply safe lint fixes.
+bun run format      # Format repository files.
+bun run analyze     # Find unused files, exports, and dependencies.
 ```
 
-### Writing Tests
+Run the CLI from source while developing:
 
-- Place test files in colocated `src/**/__tests__/` directories
-- Use descriptive test names that explain the behavior being tested
-- Follow the existing test patterns in the codebase
-- Test both success and error cases
-
-Example test structure:
-
-```typescript
-import { test, expect, describe } from "bun:test"
-
-describe("feature name", () => {
-  test("should do something specific", () => {
-    // Arrange
-    const input = "test input"
-
-    // Act
-    const result = yourFunction(input)
-
-    // Assert
-    expect(result).toBe("expected output")
-  })
-})
+```sh
+bun run src/index.ts --help
+bun run src/index.ts doctor
 ```
 
-## 📝 Code Standards
+Build before testing the packaged executable:
 
-### Code Style
-
-- We use [oxc](https://oxc.rs/) (oxlint and oxfmt) for linting and formatting
-- Code is automatically formatted on commit
-- Follow TypeScript strict mode requirements
-- Use meaningful variable and function names
-- Add JSDoc comments for public APIs
-
-### Commit Messages
-
-Use conventional commit format:
-
-- `feat: add new CLI command for updating dependencies`
-- `fix: resolve issue with monorepo detection`
-- `docs: update README with new configuration options`
-- `refactor: simplify command parsing logic`
-- `test: add tests for init command`
-
-## 🔄 Pull Request Process
-
-### Before Submitting
-
-1. Ensure all tests pass: `bun test`
-2. Check for issues: `bun run check`
-3. Auto-fix issues: `bun run fix`
-4. Format code: `bun run format`
-5. **Add a changeset if user-facing**: Run `bunx changeset` when your change affects users of the published package
-6. Update documentation if needed
-7. Add tests for new features
-
-### Submitting Your PR
-
-1. Push your branch to your fork
-2. Create a pull request against the `main` branch
-3. Fill out the PR template with:
-   - Description of changes
-   - Why the change is needed
-   - How to test the changes
-   - Any breaking changes
-
-### PR Review Process
-
-- All PRs require at least one review
-- CI checks must pass (linting, formatting, tests)
-- Maintainers may request changes or ask questions
-- Once approved, maintainers will merge your PR
-
-## 🐛 Reporting Issues
-
-### Bug Reports
-
-When reporting bugs, please include:
-
-- Adamantite version (`npx adamantite --version`)
-- Operating system and version
-- Node.js/Bun version
-- Minimal reproduction steps
-- Expected vs actual behavior
-- Error messages or logs
-
-### Feature Requests
-
-For new features:
-
-- Describe the problem you're solving
-- Explain your proposed solution
-- Consider how it fits with existing functionality
-- Provide examples of usage
-
-## 📦 Release Process
-
-Adamantite uses [changesets](https://github.com/changesets/changesets) for version management:
-
-1. **Adding a changeset**: Run `bunx changeset` when a change affects users of the published package, such as CLI behavior, presets, package exports, runtime dependencies, or user-facing documentation
-2. **Version bumping**: Maintainers run `bun run version`
-3. **Publishing**: Automated via GitHub Actions on merge to main
-
-### Types of Changes
-
-- **patch**: Bug fixes, minor improvements
-- **minor**: New features, backwards compatible
-- **major**: Breaking changes
-
-## 💡 Development Tips
-
-### Working with the CLI
-
-Test your CLI changes locally:
-
-```bash
-# Build the CLI
+```sh
 bun run build
-
-# Test commands locally
 ./bin/adamantite --help
-./bin/adamantite init --help
 ```
 
-### Debugging
+## Make a change
 
-- Use `console.log` for quick debugging
-- Bun has built-in debugging support
-- Add `debugger` statements for breakpoints
+- Keep command modules thin and put reusable behavior in `src/lib`.
+- Keep integration modules limited to their default integration export. Put shared logic in
+  `src/lib/workspace` or `src/lib/shared`.
+- Keep one-time legacy transitions in `src/lib/migrations`.
+- Do not make `assess` mutate files. `doctor --fix` is the mutating assessment dispatcher.
+- Add or update tests for behavior changes. Tests are colocated in `__tests__` directories.
+- Update user documentation when CLI behavior, presets, exports, or requirements change.
 
-### Project Structure
+## Validate a change
 
+Run the full repository workflow before you open a pull request:
+
+```sh
+bun run test
+bun run check
+bun run fix
+bun run format
 ```
-src/
-├── commands/          # CLI command implementations
-├── helpers/           # Helper modules (packages, editors, CI)
-├── index.ts          # Main CLI entry point
-├── types.ts          # TypeScript type definitions
-├── utils.ts          # Shared utilities
-└── version.ts        # Version information
-presets/
-├── oxlint/           # oxlint configuration presets
-├── oxfmt.json        # oxfmt configuration preset
-└── tsconfig.json     # TypeScript configuration preset
+
+Run `bun run analyze` after you add or remove dependencies or change imports and exports.
+Review all automatic fixes before you commit them.
+
+## Changesets
+
+Add a changeset for a change that affects users of the published package. Examples include
+CLI behavior, presets, package exports, runtime dependencies, and documentation included
+with the package.
+
+```sh
+bunx changeset
 ```
 
-## 📞 Getting Help
+Do not add a changeset for tests, CI, contributor documentation, release tooling, or other
+internal maintenance. Do not create a major changeset unless the breaking change is
+intentional and approved.
 
-- **Discussions**: Use GitHub Discussions for questions
-- **Issues**: Report bugs or request features via GitHub Issues
-- **Email**: Contact the maintainer at hello@adelrodriguez.com
+## Pull requests
 
-## 🤝 Code of Conduct
+A pull request should explain:
 
-- Be respectful and inclusive
-- Focus on constructive feedback
-- Help others learn and grow
-- Follow the Golden Rule
+- What changed.
+- Why the change is needed.
+- How the change was validated.
+- Whether it changes public behavior or requires migration.
 
----
-
-Thank you for contributing to Adamantite! Your contributions help make TypeScript development better for everyone. 🚀
+All CI checks must pass before merge. Report bugs and request features through
+[GitHub Issues](https://github.com/adelrodriguez/adamantite/issues).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">💠 Adamantite</h1>
   <p align="center">
-    <strong>Opinionated linting, formatting, type-safety and code quality presets for modern TypeScript applications.</strong>
+    <strong>Opinionated code-quality tooling for modern TypeScript projects.</strong>
   </p>
 </p>
 
@@ -17,73 +17,61 @@
   </a>
 </p>
 
-Adamantite is a collection of presets for
-[oxlint](https://oxc.rs/docs/guide/usage/linter.html),
-[oxfmt](https://oxc.rs/docs/guide/usage/formatter.html),
-[TypeScript](https://www.typescriptlang.org/) and
-[sherif](https://github.com/QuiiBz/sherif) that are designed to help humans and agents write
-maintainable and scalable type-safe code, both for individual projects and monorepos.
+Adamantite provides one CLI and a set of presets for linting, formatting, type checking,
+dependency analysis, and monorepo checks. It configures Oxlint, Oxfmt, TypeScript, Knip,
+and Sherif so humans and coding agents can use the same project workflow.
 
 ---
 
-## Quick Start
-
-Run the following command on your project to get started:
-
-```shell
-npx adamantite init
-```
-
-Adamantite will automatically configure your project with linting, formatting, and type-safety rules.
-
-```shell
-adamantite check          # Check code for issues and type errors using oxlint
-adamantite fix            # Fix code issues using oxlint
-adamantite format         # Format code using oxfmt
-adamantite monorepo       # Check monorepo for dependency issues using Sherif
-adamantite update         # Update Adamantite's dependencies to the latest compatible versions
-```
-
 ## Features
 
-- **⚡ Fast performance**: Built on oxc's Rust-based architecture for 10-40x faster linting than ESLint
-- **🔍 Extensive linting**: 500+ rules covering correctness, performance, security, and accessibility
-- **🎯 Zero configuration**: Works out of the box with sensible defaults, no setup required
-- **🔧 Single tool solution**: Leverages the oxc ecosystem for linting and formatting
-- **🛡️ Strict type safety**: Comes with a strict TypeScript preset to improve type safety across your codebase
-- **🏗️ Monorepo support**: Unified configuration and dependency management across workspace packages
-- **⚙️ CI-friendly**: Automatically configures GitHub Actions workflows to run checks in CI
-- **🤖 AI-friendly patterns**: Consistent code style designed for effective AI collaboration
+- **Fast checks**: Run Oxlint and Oxfmt on the Oxc toolchain.
+- **Strict defaults**: Use opinionated lint and TypeScript presets without assembling a
+  configuration from scratch.
+- **Framework presets**: Add rules for React, Next.js, Vue, Node.js, Jest, or Vitest.
+- **Project setup**: Create package scripts, configuration files, editor settings, and CI
+  through an interactive or non-interactive initializer.
+- **Setup maintenance**: Assess managed integrations with `doctor`, apply safe fixes, and
+  migrate older Adamantite configurations.
+- **Workspace checks**: Find unused code with Knip and dependency inconsistencies with
+  Sherif.
+- **Agent guidance**: Add a managed Adamantite section to `AGENTS.md`.
 
-## Installation
+## Quick start
 
-### Automatic Setup (Recommended)
+Run the initializer from the root of a TypeScript project:
 
-```shell
+```sh
 npx adamantite init
 ```
 
-This interactive command will:
+The interactive setup lets you choose package scripts, presets, TypeScript, editors, CI,
+and agent guidance. After setup, use the scripts written to `package.json`:
 
-- Install Adamantite, [oxlint](https://oxc.rs/docs/guide/usage/linter.html), and [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) as dev dependencies
-- Create `oxlint.config.ts` with opinionated presets
-- Create `oxfmt.config.ts` with formatting configuration
-- Set up `tsconfig.json` with strict TypeScript rules
-- Add lint/format scripts to your `package.json`
-  - Also adds monorepo-specific scripts if running a monorepo
-- Configure editor settings
+```sh
+bun run check
+bun run fix
+bun run format
+bun run analyze
+```
 
-### Non-interactive setup for agents
+Use the equivalent `adamantite` commands directly when the project does not have managed
+scripts:
 
-Use `--non-interactive` to configure a project entirely from flags. At least one
-`--script` is required, repeat `--script`, `--preset`, and `--editor` to select multiple
-values, and add boolean flags only when that setup should be enabled.
+```sh
+adamantite check
+adamantite fix
+adamantite format
+adamantite analyze
+adamantite monorepo
+```
 
-```shell
-# Minimal unattended setup
-npx adamantite init --non-interactive --script check
+## Non-interactive setup
 
-# Fully specified unattended setup
+Use `--non-interactive` to configure a project entirely from flags. Specify at least one
+`--script`. Repeat `--script`, `--preset`, and `--editor` to select multiple values.
+
+```sh
 npx adamantite init \
   --non-interactive \
   --script check \
@@ -91,7 +79,6 @@ npx adamantite init \
   --script format \
   --script analyze \
   --preset react \
-  --preset node \
   --editor vscode \
   --typescript \
   --install-extensions \
@@ -99,202 +86,163 @@ npx adamantite init \
   --agents
 ```
 
-The available values are:
+Available setup values:
 
-- Scripts: `check`, `fix`, `format`, `analyze`, `check:monorepo`, and `fix:monorepo`
-- Presets: `react`, `nextjs`, `vue`, `jest`, `vitest`, and `node`
-- Editors: `vscode` and `zed`
+- Scripts: `check`, `fix`, `format`, `analyze`, `check:monorepo`, and `fix:monorepo`.
+- Presets: `react`, `nextjs`, `vue`, `jest`, `vitest`, and `node`.
+- Editors: `vscode` and `zed`.
 
-Omitted boolean flags are disabled. Setup flags require `--non-interactive`; without it,
-`adamantite init` keeps the interactive setup flow.
+Presets and TypeScript require the `check` or `fix` script. Editor extension installation
+requires an editor. Monorepo scripts require a detected monorepo. GitHub Actions requires a
+compatible script and a supported package manager. Omitted boolean flags are disabled.
 
-## 📋 Commands
+## Commands
 
-### `adamantite analyze`
-
-Find unused dependencies, exports, and files using Knip:
-
-```shell
-# Analyze the current project
-adamantite analyze
-
-# Automatically fix issues, including removing unused files
-adamantite analyze --fix
-
-# Enable production and strict analysis
-adamantite analyze --strict
-
-# Forward additional arguments to Knip
-adamantite analyze -- --directory packages/app
-```
+Run `adamantite --help` or `adamantite <command> --help` for the complete CLI reference.
 
 ### `adamantite check`
 
-Check your code for issues and type errors without automatically fixing them using oxlint:
+Find lint and type errors without changing files:
 
-```shell
-# Check all files
+```sh
 adamantite check
-
-# Check specific files
-adamantite check src/components/**/*.ts
+adamantite check src
 ```
 
 ### `adamantite fix`
 
-Fix issues in your code with automatic formatting and safe fixes:
+Apply safe Oxlint fixes. Suggested and dangerous fixes require explicit flags:
 
-```shell
-# Fix all files
+```sh
 adamantite fix
-
-# Fix specific files
-adamantite fix src/index.ts
-
-# Apply suggested fixes
 adamantite fix --suggested
-
-# Apply dangerous fixes
 adamantite fix --dangerous
-
-# Apply all fixes
 adamantite fix --all
 ```
 
 ### `adamantite format`
 
-Format your code using oxfmt:
+Format files with Oxfmt, or check formatting without writing:
 
-```shell
-# Format all files
+```sh
 adamantite format
-
-# Format specific files
 adamantite format src/index.ts
-
-# Check if files are formatted without writing
 adamantite format --check
+```
+
+### `adamantite analyze`
+
+Find unused dependencies, exports, and files with Knip. The `--fix` option can remove
+unused files, so review its effect before use.
+
+```sh
+adamantite analyze
+adamantite analyze --strict
+adamantite analyze --fix
 ```
 
 ### `adamantite monorepo`
 
-Special tooling for monorepo projects using [Sherif](https://github.com/QuiiBz/sherif):
+Find dependency consistency problems in a monorepo with Sherif:
 
-```shell
-# Check for monorepo-specific issues
+```sh
 adamantite monorepo
-
-# Fix monorepo-specific issues
 adamantite monorepo --fix
 ```
 
-Automatically detects and fixes:
+### `adamantite doctor`
 
-- Inconsistent dependency versions across packages
-- Missing dependencies in package.json
-- Unused dependencies
-- Package.json formatting issues
+Assess every Adamantite-managed integration. The default command is read-only. Use
+`--fix` to install or update managed packages, create missing supported configurations,
+update supported configurations, and run known migrations.
 
-### Passing arguments to underlying tools
+```sh
+adamantite doctor
+adamantite doctor --fix
+adamantite doctor
+```
 
-Commands that invoke Knip, Oxlint, Oxfmt, or Sherif can forward additional arguments to
-the underlying CLI. Place Adamantite arguments before `--` and underlying CLI arguments
-after it:
+Manual-fix findings remain report-only.
 
-```shell
+### `adamantite update`
+
+Run applicable migrations and update Adamantite-managed dependencies:
+
+```sh
+adamantite update
+adamantite doctor --fix
+adamantite doctor
+```
+
+`update` handles known legacy transitions, including JSON Oxlint, Oxfmt, and Knip
+configurations and the legacy type-check script. Use `doctor --fix` afterward to complete
+safe setup repairs.
+
+### Pass arguments to underlying tools
+
+Commands that invoke Knip, Oxlint, Oxfmt, or Sherif forward arguments after `--`:
+
+```sh
 adamantite analyze --strict -- --directory packages/app
 adamantite check src -- --deny-warnings
 adamantite format -- --ignore-path .formatignore
 adamantite monorepo -- --ignore-package package-a
 ```
 
-When invoking a package script, the package manager consumes its own `--`, so add a
-second separator for Adamantite:
+Package managers consume one separator, so package scripts need a second one:
 
-```shell
+```sh
 bun run analyze -- -- --directory packages/app
 npm run analyze -- -- --directory packages/app
 ```
 
-Passthrough arguments are not supported by `init`, `doctor`, or `update`, because those
-commands do not invoke a single underlying CLI.
-
-### `adamantite update`
-
-Run applicable migrations and update Adamantite-managed dependencies:
-
-```shell
-# Run migrations and update managed dependencies
-adamantite update
-```
-
-This also migrates legacy `.oxfmtrc.json(c)` configs to `oxfmt.config.ts` and `knip.json(c)` configs to `knip.config.ts`.
+`init`, `doctor`, and `update` do not forward arguments because they do not invoke one
+underlying CLI.
 
 ## Presets
 
-### Linting ([presets/lint/](./presets/lint/))
+Adamantite publishes configuration that can also be consumed directly:
 
-Adamantite provides comprehensive linting rules for TypeScript and JavaScript:
+| Export                   | Purpose                                    |
+| ------------------------ | ------------------------------------------ |
+| `adamantite/lint`        | Core Oxlint rules.                         |
+| `adamantite/lint/react`  | React, JSX accessibility, and performance. |
+| `adamantite/lint/nextjs` | Next.js rules.                             |
+| `adamantite/lint/vue`    | Vue rules.                                 |
+| `adamantite/lint/node`   | Node.js rules.                             |
+| `adamantite/lint/jest`   | Jest rules.                                |
+| `adamantite/lint/vitest` | Vitest rules.                              |
+| `adamantite/format`      | Oxfmt configuration.                       |
+| `adamantite/analyze`     | Knip configuration.                        |
+| `adamantite/typescript`  | Strict TypeScript configuration for TS 7+. |
 
-#### Core ([core.ts](./presets/lint/core.ts))
+## Requirements and boundaries
 
-Extensive ruleset covering:
+- Adamantite requires Node.js 24 or later when run with Node.js.
+- This repository uses Bun, but the CLI can configure projects that use Bun, Deno, npm,
+  pnpm, or Yarn where the selected integration supports them.
+- Adamantite manages recognized package scripts and supported configuration shapes. It
+  reports custom configurations that require manual work instead of overwriting them.
+- `fix`, `format`, `analyze --fix`, `monorepo --fix`, `doctor --fix`, `init`, and `update`
+  can change project files. Review the resulting diff.
 
-- **Correctness**: Bug prevention and code correctness enforcement
-- **Performance**: Optimization patterns and performance best practices
-- **Restriction**: Enforcing coding standards and preventing problematic patterns
-- **Suspicious**: Detecting code smells and potential bugs
-- **Pedantic**: Strict code quality and consistency enforcement
-- **Style**: Consistent code formatting and naming conventions
-- **Nursery**: Experimental rules under active development
+## Agent skill
 
-#### Framework Presets
+Install the first-party Adamantite skill to teach coding agents how to initialize, assess,
+repair, and update a project:
 
-Framework-specific presets are available for:
+```sh
+npx skills add adelrodriguez/adamantite --list
+npx skills add adelrodriguez/adamantite --skill adamantite
+```
 
-- **React** ([react.ts](./presets/lint/react.ts)) - React, React-perf, and JSX-a11y rules
-- **Next.js** ([nextjs.ts](./presets/lint/nextjs.ts)) - Next.js-specific rules
-- **Vue** ([vue.ts](./presets/lint/vue.ts)) - Vue.js rules
-- **Node.js** ([node.ts](./presets/lint/node.ts)) - Node.js-specific rules
-- **Jest** ([jest.ts](./presets/lint/jest.ts)) - Jest testing rules
-- **Vitest** ([vitest.ts](./presets/lint/vitest.ts)) - Vitest testing rules
+## Contributing
 
-### Formatting ([format.ts](./presets/format.ts))
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository workflow. Contributors should
+also read the [domain glossary](CONTEXT.md) and [architecture reference](docs/architecture.md).
 
-Opinionated code formatting with oxfmt, configured for consistency and readability. The published formatter preset is available as `adamantite/format` and is designed to be used from `oxfmt.config.ts`.
+## License
 
-### Analyze ([analyze.ts](./presets/analyze.ts))
+Adamantite uses the [MIT License](LICENSE).
 
-Opinionated Knip configuration for dependency and unused-file analysis. The published analyze preset is available as `adamantite/analyze` and is designed to be used from `knip.config.ts`.
-
-### TypeScript ([presets/tsconfig.json](./presets/tsconfig.json))
-
-Strict TypeScript configuration for maximum type safety. Catches errors at compile-time that would otherwise cause runtime failures. The preset requires TypeScript 7 or newer.
-
-````
-
-## 🛠️ Development
-
-This project uses Bun for all development tasks:
-
-```shell
-# Install dependencies
-bun install
-
-# Run tests
-bun test
-
-# Build CLI
-bun run build
-
-# Linting and type checking
-bun run check
-````
-
-## 🤝 Contributing
-
-Contributions are welcome! Please read our [contributing guidelines](CONTRIBUTING.md) first.
-
-## 📄 License
-
-MIT © [Adel Rodriguez](https://github.com/adelrodriguez)
+Made with [🥐 `pastry`](https://github.com/adelrodriguez/pastry)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,3 @@
+# Architecture decision records
+
+No architecture decision records have been accepted yet.

--- a/docs/agents/changesets.md
+++ b/docs/agents/changesets.md
@@ -1,0 +1,14 @@
+# Changesets
+
+This repository uses Changesets for versioning and changelog management.
+
+## Agent rules
+
+- Add a changeset for CLI behavior, presets, package exports, runtime dependencies, and
+  documentation shipped with the package.
+- Do not add a changeset for tests, CI, contributor documentation, release tooling, or
+  internal maintenance.
+- Use `bunx changeset` to create a changeset.
+- Never make a major version bump unless the user requests it.
+- If a change is breaking and the current package version is 1.0.0 or higher, alert the
+  user.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,51 +1,22 @@
-# Domain Docs
+# Domain docs
 
-How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+This repository uses a single-context domain-doc layout.
 
-## Before exploring, read these
+## Before you explore
 
-- **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+Read these files when they exist:
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+- `CONTEXT.md` at the repository root.
+- Relevant ADRs in `docs/adr/`.
 
-## File structure
+If a file does not exist, continue without a warning. Domain-modeling skills create these
+files when the project resolves terms or decisions.
 
-Single-context repo (most repos):
+## Vocabulary
 
-```
-/
-├── CONTEXT.md
-├── docs/adr/
-│   ├── 0001-event-sourced-orders.md
-│   └── 0002-postgres-for-write-model.md
-└── src/
-```
+Use the terms from the `CONTEXT.md` glossary. Do not replace defined terms with synonyms.
 
-Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+## ADR conflicts
 
-```
-/
-├── CONTEXT-MAP.md
-├── docs/adr/                          ← system-wide decisions
-└── src/
-    ├── ordering/
-    │   ├── CONTEXT.md
-    │   └── docs/adr/                  ← context-specific decisions
-    └── billing/
-        ├── CONTEXT.md
-        └── docs/adr/
-```
-
-## Use the glossary's vocabulary
-
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
-
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
-
-## Flag ADR conflicts
-
-If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
-
-> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+State when proposed work conflicts with an ADR. Do not silently replace an accepted
+decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,22 +1,29 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+Issues and PRDs for this repository live in GitHub Issues. Use the `gh` CLI for all
+operations.
+
+## Repository
+
+`adelrodriguez/adamantite`
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments` for human-readable output. For scripted use, fetch JSON with `gh issue view <number> --json number,title,body,labels,comments --jq '{number, title, body, labels: [.labels[].name], comments: [.comments[].body]}'`.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
+- Create: `gh issue create --title "..." --body "..."`.
+- Read: `gh issue view <number> --comments`.
+- List: `gh issue list`.
+- Comment: `gh issue comment <number> --body "..."`.
+- Label: `gh issue edit <number> --add-label "..."`.
+- Close: `gh issue close <number> --comment "..."`.
 
-Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+Infer the repository from the Git remote when possible.
 
-## When a skill says "publish to the issue tracker"
+## Pull requests as a request surface
 
-Create a GitHub issue.
+PRs as a request surface: no.
 
-## When a skill says "fetch the relevant ticket"
+## Skill operations
 
-Run `gh issue view <number> --comments`.
+When a skill says to publish to the issue tracker, create a GitHub issue. When a skill says
+to fetch a ticket, read the GitHub issue and its comments. Use GitHub sub-issues and native
+dependencies for wayfinding when available.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,14 @@
-# Triage Labels
+# Triage labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+The skills use five canonical triage roles. This file maps those roles to the labels in
+this repository's issue tracker.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
-| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+| Role              | Label             | Meaning                                     |
+| ----------------- | ----------------- | ------------------------------------------- |
+| `needs-triage`    | `needs-triage`    | A maintainer must evaluate the issue.       |
+| `needs-info`      | `needs-info`      | More information is required.               |
+| `ready-for-agent` | `ready-for-agent` | An agent can implement the specified work.  |
+| `ready-for-human` | `ready-for-human` | The work requires a human.                  |
+| `wontfix`         | `wontfix`         | The project will not implement the request. |
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
-
-Edit the right-hand column to match whatever vocabulary you actually use.
+Use the label in the second column when a skill refers to a triage role.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,99 @@
+# Architecture
+
+Adamantite is a preset package and CLI that applies and maintains code-quality tooling in
+a target project. Product behavior is documented in the [README](../README.md), domain
+terms live in [CONTEXT.md](../CONTEXT.md), and durable tradeoffs belong in
+[decision records](./adr/README.md).
+
+## Runtime
+
+`src/index.ts` starts the Effect runtime. `src/cli.ts` defines the command tree and command
+options. Command modules validate command-specific input, obtain Effect services, and
+invoke target-project operations.
+
+`@effect/platform-node` supplies the production filesystem, path, process, and terminal
+services. Other external behavior, such as prompts and child commands, is also behind
+services so command behavior can be tested without changing a real project.
+
+Bunup bundles the CLI and presets into `dist`. The `bin/adamantite` executable loads the
+bundled CLI.
+
+## Module seams
+
+| Module         | Responsibility                                                                     |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `commands`     | Define one CLI workflow and render its user-facing result.                         |
+| `integrations` | Detect and maintain supported tooling, editor, workspace, and CI state.            |
+| `migrations`   | Perform one-time transitions from legacy state.                                    |
+| `workspace`    | Read and write target-project files and derive workspace state.                    |
+| `services`     | Isolate prompts, child commands, dependency installation, and argument forwarding. |
+| `shared`       | Define assessments, errors, filesystem helpers, JSON helpers, and terminal output. |
+| `presets`      | Publish lint, format, analysis, and TypeScript configuration.                      |
+
+Integration modules export only the integration itself as a default export.
+`src/lib/integrations/base.ts` is the shared infrastructure exception. Reusable behavior
+belongs in a nearby workspace or shared module instead of a named integration export.
+
+## Integration lifecycle
+
+```mermaid
+flowchart TD
+  A[Detect current state] --> B[Assess without mutation]
+  B --> C{Assessment action}
+  C -->|No action| D[Report healthy]
+  C -->|Create config| E[Integration create]
+  C -->|Update config| F[Integration update]
+  C -->|Run migration| G[Migration system]
+  C -->|Manual fix| H[Report guidance only]
+```
+
+`assess` is always read-only. It must not write files or call migrations. `doctor` reports
+the resulting assessments. `doctor --fix` is the only dispatcher that turns assessment
+actions into mutations; manual fixes remain report-only.
+
+Migrations may call integrations to reach the latest supported shape. Integrations must
+not call migrations. This dependency direction keeps normal maintenance separate from
+one-time legacy transitions.
+
+`init` creates selected setup for a target project. It does not orchestrate migrations. If
+it finds existing setup that it intentionally leaves unchanged, it warns the user and
+points to `adamantite doctor` or `adamantite doctor --fix`.
+
+## Command boundaries
+
+- `check`, `fix`, and `format` run Oxlint or Oxfmt.
+- `analyze` runs Knip.
+- `monorepo` runs Sherif.
+- `init` creates selected integrations and managed scripts.
+- `doctor` assesses managed integrations; `doctor --fix` applies safe assessment actions.
+- `update` runs applicable migrations and updates managed dependencies.
+- `typecheck` is a deprecated alias for `check`.
+
+Commands that wrap one underlying tool can forward arguments after `--`. Lifecycle
+commands do not forward arguments because they coordinate multiple operations.
+
+## Source layout
+
+```text
+presets/
+  lint/             published Oxlint presets
+  analyze.ts        published Knip preset
+  format.ts         published Oxfmt preset
+  tsconfig.json     published TypeScript preset
+src/
+  commands/         CLI workflows
+  lib/
+    integrations/   tooling, editor, and CI adapters
+    migrations/     one-time legacy transitions
+    services/       injectable external behavior
+    shared/         cross-cutting types and helpers
+    workspace/      target-project state and file operations
+  cli.ts            command definition
+  index.ts          composition root and runtime boundary
+```
+
+## Dependency version invariant
+
+A tooling integration records the version that Adamantite installs in target projects.
+When the corresponding dependency version in `package.json` increases, update the version
+in `src/lib/integrations/tooling` to match.

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -13,7 +13,7 @@ import * as Layer from "effect/Layer"
 import * as Result from "effect/Result"
 import * as Terminal from "effect/Terminal"
 import { runResult } from "#__tests__/helpers.ts"
-import { isJsonObject, mergeConfig, parseJson, serializeTsObjectLiteral } from "#lib/shared/json.ts"
+import { mergeConfig, parseJson, serializeTsObjectLiteral } from "#lib/shared/json.ts"
 import { checkCliExists } from "#lib/shared/process.ts"
 import { printTitle } from "#lib/shared/terminal.ts"
 import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
@@ -191,22 +191,6 @@ describe("parseJson", () => {
     if (Result.isFailure(result)) {
       expect(result.failure).toMatchObject({ _tag: "FailedToParseFile" })
     }
-  })
-})
-
-describe("isJsonObject", () => {
-  test("return true for plain JSON objects", () => {
-    expect(isJsonObject({})).toBe(true)
-    expect(isJsonObject({ a: 1, b: "x", c: null, d: [1, 2, 3] })).toBe(true)
-  })
-
-  test("return false for null, arrays, and primitives", () => {
-    expect(isJsonObject(null)).toBe(false)
-    expect(isJsonObject([])).toBe(false)
-    expect(isJsonObject([1, 2, 3])).toBe(false)
-    expect(isJsonObject("x")).toBe(false)
-    expect(isJsonObject(123)).toBe(false)
-    expect(isJsonObject(true)).toBe(false)
   })
 })
 

--- a/src/lib/integrations/ci/__tests__/github.test.ts
+++ b/src/lib/integrations/ci/__tests__/github.test.ts
@@ -9,6 +9,13 @@ import * as Result from "effect/Result"
 import { runResult } from "#__tests__/helpers.ts"
 import github from "#lib/integrations/ci/github.ts"
 
+function getActionReference(content: string, action: string): string | undefined {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(`uses: ${action}@`))
+}
+
 describe("github", () => {
   let originalCwd: string
   let tempDir: string
@@ -57,13 +64,36 @@ describe("github", () => {
       expect(content).toContain("name: check")
       expect(content).toContain("command: bun run check")
       expect(content).toContain("Setup Node.js")
-      expect(content).toContain("actions/setup-node@v6")
-      expect(content).toContain('node-version: "22"')
+      expect(content).toContain("actions/setup-node@v7")
+      expect(content).toContain('node-version: "24"')
       expect(content).toContain("Setup Bun")
       expect(content).toContain("Cache dependencies")
-      expect(content).toContain("actions/cache@v4")
+      expect(content).toContain("actions/cache@v6")
       expect(content).toContain("~/.bun/install/cache")
       expect(content).toContain("bun install --frozen-lockfile")
+    })
+
+    test("keep shared action versions aligned with this repository's CI workflow", async () => {
+      await github
+        .create(tempDir, {
+          packageManager: "bun",
+          scripts: ["check"],
+        })
+        .pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const generatedWorkflow = await Bun.file(".github/workflows/adamantite.yml").text()
+      const referenceWorkflow = await Bun.file(join(originalCwd, ".github/workflows/ci.yml")).text()
+
+      for (const action of [
+        "actions/checkout",
+        "actions/setup-node",
+        "oven-sh/setup-bun",
+        "actions/cache",
+      ]) {
+        expect(getActionReference(generatedWorkflow, action)).toBe(
+          getActionReference(referenceWorkflow, action)
+        )
+      }
     })
 
     test("generate the correct workflow for npm", async () => {
@@ -76,7 +106,7 @@ describe("github", () => {
 
       const content = await Bun.file(".github/workflows/adamantite.yml").text()
       expect(content).toContain("Setup Node.js")
-      expect(content).toContain("actions/setup-node@v6")
+      expect(content).toContain("actions/setup-node@v7")
       expect(content).toContain('cache: "npm"')
       expect(content).toContain("npm ci")
       expect(content).toContain("command: npm run check")
@@ -93,7 +123,7 @@ describe("github", () => {
       const content = await Bun.file(".github/workflows/adamantite.yml").text()
       expect(content).toContain("Setup pnpm")
       expect(content).toContain("pnpm/action-setup@v4")
-      expect(content).toContain("actions/setup-node@v6")
+      expect(content).toContain("actions/setup-node@v7")
       expect(content).toContain('cache: "pnpm"')
       expect(content).toContain("pnpm install --frozen-lockfile")
       expect(content).toContain("command: pnpm run check")
@@ -109,7 +139,7 @@ describe("github", () => {
 
       const content = await Bun.file(".github/workflows/adamantite.yml").text()
       expect(content).toContain("Setup Node.js")
-      expect(content).toContain("actions/setup-node@v6")
+      expect(content).toContain("actions/setup-node@v7")
       expect(content).toContain('cache: "yarn"')
       expect(content).toContain("yarn install --frozen-lockfile")
       expect(content).toContain("command: yarn run check")

--- a/src/lib/integrations/ci/github.ts
+++ b/src/lib/integrations/ci/github.ts
@@ -14,15 +14,15 @@ interface WorkflowOptions {
 
 const setupSteps: Record<SupportedPackageManager, string> = {
   bun: `      - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.bun/install/cache
@@ -39,9 +39,9 @@ const setupSteps: Record<SupportedPackageManager, string> = {
       - name: Install dependencies
         run: deno install --frozen`,
   npm: `      - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -50,17 +50,17 @@ const setupSteps: Record<SupportedPackageManager, string> = {
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile`,
   yarn: `      - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "yarn"
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ ${matrixInclude}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
 ${setupSteps[packageManager]}
 

--- a/src/lib/integrations/editors/__tests__/vscode.test.ts
+++ b/src/lib/integrations/editors/__tests__/vscode.test.ts
@@ -82,6 +82,19 @@ describe("vscode", () => {
       expect(config["editor.formatOnPaste"]).toBe(true)
     })
 
+    test("remain idempotent across repeated updates", async () => {
+      mkdirSync(".vscode", { recursive: true })
+      await Bun.write(".vscode/settings.json", JSON.stringify({ "editor.tabSize": 4 }, null, 2))
+
+      await vscode.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+      const firstUpdate = await Bun.file(".vscode/settings.json").text()
+
+      await vscode.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+      const secondUpdate = await Bun.file(".vscode/settings.json").text()
+
+      expect(secondUpdate).toBe(firstUpdate)
+    })
+
     test("merge an empty config with Adamantite's config", async () => {
       mkdirSync(".vscode", { recursive: true })
       await Bun.write(".vscode/settings.json", "{}")

--- a/src/lib/integrations/editors/__tests__/zed.test.ts
+++ b/src/lib/integrations/editors/__tests__/zed.test.ts
@@ -75,6 +75,119 @@ describe("zed", () => {
       expect(config.lsp.oxfmt.initialization_options.settings.run).toBe("onSave")
     })
 
+    test("deduplicate formatter entries for managed languages", async () => {
+      mkdirSync(join(tempDir, ".zed"), { recursive: true })
+      await Bun.write(
+        join(tempDir, ".zed", "settings.json"),
+        JSON.stringify({
+          languages: {
+            JavaScript: {
+              formatter: [
+                { language_server: { name: "oxfmt" } },
+                { language_server: { name: "oxfmt" } },
+              ],
+            },
+          },
+        })
+      )
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+      const config = JSON.parse(content)
+
+      expect(config.languages.JavaScript.formatter).toEqual([
+        { language_server: { name: "oxfmt" } },
+        { code_action: "source.fixAll.oxc" },
+      ])
+    })
+
+    test("preserve repeated values in user-owned arrays", async () => {
+      mkdirSync(join(tempDir, ".zed"), { recursive: true })
+      await Bun.write(
+        join(tempDir, ".zed", "settings.json"),
+        JSON.stringify({
+          languages: {
+            JavaScript: {
+              formatter: [{ language_server: { name: "oxfmt" } }],
+            },
+          },
+          lsp: {
+            custom: {
+              initialization_options: {
+                arguments: ["--flag", "--flag"],
+              },
+            },
+          },
+        })
+      )
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+      const config = JSON.parse(content)
+
+      expect(config.lsp.custom.initialization_options.arguments).toEqual(["--flag", "--flag"])
+      expect(config.languages.JavaScript.formatter).toHaveLength(2)
+    })
+
+    test("preserve formatter entries for unmanaged languages", async () => {
+      const formatter = [{ external: "custom" }, { external: "custom" }]
+      mkdirSync(join(tempDir, ".zed"), { recursive: true })
+      await Bun.write(
+        join(tempDir, ".zed", "settings.json"),
+        JSON.stringify({ languages: { Astro: { formatter } } })
+      )
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+      const config = JSON.parse(content)
+
+      expect(config.languages.Astro.formatter).toEqual(formatter)
+    })
+
+    test("preserve repeated values nested in managed formatter entries", async () => {
+      const formatter = {
+        language_server: {
+          arguments: ["--flag", "--flag"],
+          name: "custom",
+        },
+      }
+      mkdirSync(join(tempDir, ".zed"), { recursive: true })
+      await Bun.write(
+        join(tempDir, ".zed", "settings.json"),
+        JSON.stringify({ languages: { JavaScript: { formatter: [formatter, formatter] } } })
+      )
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+      const config = JSON.parse(content)
+
+      expect(config.languages.JavaScript.formatter).toContainEqual(formatter)
+      expect(config.languages.JavaScript.formatter).toHaveLength(3)
+    })
+
+    test("remain idempotent across repeated updates", async () => {
+      mkdirSync(join(tempDir, ".zed"), { recursive: true })
+      await Bun.write(
+        join(tempDir, ".zed", "settings.json"),
+        JSON.stringify({ ui_font_size: 14 }, null, 2)
+      )
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+      const firstUpdate = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+
+      await zed.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+      const secondUpdate = await Bun.file(join(tempDir, ".zed", "settings.json")).text()
+      const config = JSON.parse(secondUpdate)
+
+      expect(secondUpdate).toBe(firstUpdate)
+      expect(config.languages.JavaScript.formatter).toHaveLength(2)
+      expect(config.languages.JSON.formatter).toHaveLength(1)
+    })
+
     test("merge an empty config with Adamantite's config", async () => {
       mkdirSync(join(tempDir, ".zed"), { recursive: true })
       await Bun.write(join(tempDir, ".zed", "settings.json"), "{}")

--- a/src/lib/integrations/editors/vscode.ts
+++ b/src/lib/integrations/editors/vscode.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import type { Script } from "#lib/workspace/package-json.ts"
 import { defineIntegration } from "#lib/integrations/base.ts"
@@ -13,7 +14,7 @@ import {
   InvalidConfigFormat,
   VscodeCliNotFound,
 } from "#lib/shared/errors.ts"
-import { isJsonObject, mergeConfig, parseJson } from "#lib/shared/json.ts"
+import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: ".vscode/settings.json", type: "config" }] as const
 const CONFIG = {
@@ -120,7 +121,7 @@ export default defineIntegration({
 
       const existingConfig = yield* parseJson(vscodeFile, settingsPath)
 
-      if (!isJsonObject(existingConfig)) {
+      if (!Predicate.isObject(existingConfig)) {
         return yield* new InvalidConfigFormat({ path: settingsPath })
       }
 

--- a/src/lib/integrations/editors/zed.ts
+++ b/src/lib/integrations/editors/zed.ts
@@ -1,6 +1,9 @@
+import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
+import * as Schema from "effect/Schema"
 import { defineIntegration } from "#lib/integrations/base.ts"
 import {
   FailedToCreateDirectory,
@@ -8,7 +11,7 @@ import {
   FailedToWriteFile,
   InvalidConfigFormat,
 } from "#lib/shared/errors.ts"
-import { isJsonObject, mergeConfig, parseJson } from "#lib/shared/json.ts"
+import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: ".zed/settings.json", type: "config" }] as const
 const CONFIG = {
@@ -59,6 +62,36 @@ const CONFIG = {
   },
 } as const
 
+function deduplicateManagedFormatters(config: Schema.JsonObject): Schema.JsonObject {
+  const languageSettings = config.languages
+
+  if (!Schema.is(Schema.Record(Schema.String, Schema.Json))(languageSettings)) {
+    return config
+  }
+
+  const languages = Object.fromEntries(
+    Object.entries(languageSettings).map(([language, languageConfig]) => {
+      if (
+        language in CONFIG.languages &&
+        Schema.is(Schema.Record(Schema.String, Schema.Json))(languageConfig) &&
+        Schema.is(Schema.Array(Schema.Json))(languageConfig.formatter)
+      ) {
+        return [
+          language,
+          Object.fromEntries([
+            ...Object.entries(languageConfig),
+            ["formatter", Array.dedupe(languageConfig.formatter)],
+          ]),
+        ]
+      }
+
+      return [language, languageConfig]
+    })
+  )
+
+  return { ...config, languages }
+}
+
 export default defineIntegration({
   config: files[0].path,
   create: (cwd: string) =>
@@ -97,11 +130,12 @@ export default defineIntegration({
 
       const existingConfig = yield* parseJson(zedFile, settingsPath)
 
-      if (!isJsonObject(existingConfig)) {
+      if (!Predicate.isObject(existingConfig)) {
         return yield* new InvalidConfigFormat({ path: settingsPath })
       }
 
-      const newConfig = yield* mergeConfig(CONFIG, existingConfig)
+      const mergedConfig = yield* mergeConfig(CONFIG, existingConfig)
+      const newConfig = deduplicateManagedFormatters(mergedConfig)
 
       yield* fs
         .writeFileString(settingsPath, `${JSON.stringify(newConfig, null, 2)}\n`)

--- a/src/lib/migrations/legacy-knip-json.ts
+++ b/src/lib/migrations/legacy-knip-json.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import knip from "#lib/integrations/tooling/knip.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
 import { Prompter } from "#lib/services/prompter.ts"
@@ -11,7 +12,7 @@ import {
   InvalidConfigFormat,
   MigrationValidationFailed,
 } from "#lib/shared/errors.ts"
-import { isJsonObject, parseJson } from "#lib/shared/json.ts"
+import { parseJson } from "#lib/shared/json.ts"
 import { toKnipTsConfigContent } from "#lib/workspace/knip-config.ts"
 
 function getLegacyConfigPaths() {
@@ -44,7 +45,7 @@ function migrateLegacyKnipConfig(cwd: string) {
 
     const existingConfig = yield* parseJson(legacyConfigContent, legacyConfigPath)
 
-    if (!isJsonObject(existingConfig)) {
+    if (!Predicate.isObject(existingConfig)) {
       return yield* new InvalidConfigFormat({ path: legacyConfigPath })
     }
 

--- a/src/lib/migrations/legacy-oxfmt-json.ts
+++ b/src/lib/migrations/legacy-oxfmt-json.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import oxfmt from "#lib/integrations/tooling/oxfmt.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
 import { Prompter } from "#lib/services/prompter.ts"
@@ -11,7 +12,7 @@ import {
   InvalidConfigFormat,
   MigrationValidationFailed,
 } from "#lib/shared/errors.ts"
-import { isJsonObject, parseJson } from "#lib/shared/json.ts"
+import { parseJson } from "#lib/shared/json.ts"
 import { toOxfmtTsConfigContent } from "#lib/workspace/oxfmt-config.ts"
 
 function getLegacyConfigPaths() {
@@ -44,7 +45,7 @@ function migrateLegacyOxfmtConfig(cwd: string) {
 
     const existingConfig = yield* parseJson(legacyConfigContent, legacyConfigPath)
 
-    if (!isJsonObject(existingConfig)) {
+    if (!Predicate.isObject(existingConfig)) {
       return yield* new InvalidConfigFormat({ path: legacyConfigPath })
     }
 

--- a/src/lib/migrations/legacy-oxlint-json.ts
+++ b/src/lib/migrations/legacy-oxlint-json.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
 import { Prompter } from "#lib/services/prompter.ts"
@@ -11,7 +12,7 @@ import {
   InvalidConfigFormat,
   MigrationValidationFailed,
 } from "#lib/shared/errors.ts"
-import { isJsonObject, parseJson } from "#lib/shared/json.ts"
+import { parseJson } from "#lib/shared/json.ts"
 import { getOxlintPresetNames, toOxlintTsConfigContent } from "#lib/workspace/oxlint-config.ts"
 
 function migrateLegacyOxlintConfig(cwd: string) {
@@ -33,7 +34,7 @@ function migrateLegacyOxlintConfig(cwd: string) {
 
     const existingConfig = yield* parseJson(legacyConfigContent, legacyConfigPath)
 
-    if (!isJsonObject(existingConfig)) {
+    if (!Predicate.isObject(existingConfig)) {
       return yield* new InvalidConfigFormat({ path: legacyConfigPath })
     }
 

--- a/src/lib/shared/json.ts
+++ b/src/lib/shared/json.ts
@@ -1,7 +1,9 @@
 import type { JsonValue } from "type-fest"
 import { defu } from "defu"
+
 import * as Effect from "effect/Effect"
-import * as Predicate from "effect/Predicate"
+
+import type * as Schema from "effect/Schema"
 import { type ParseError, parse } from "jsonc-parser"
 import { FailedToMergeConfig, FailedToParseFile } from "#lib/shared/errors.ts"
 
@@ -17,8 +19,6 @@ export const parseJson = (content: string, path?: string) =>
         : Effect.succeed(parsed)
     )
   )
-
-export const isJsonObject = Predicate.isObject
 
 export function serializeTsObjectLiteral(
   value: unknown,
@@ -40,7 +40,7 @@ export function serializeTsObjectLiteral(
   return serialized.replaceAll("\n", `\n${continuationIndent}`)
 }
 
-export const mergeConfig = (base: Record<string, unknown>, override: Record<string, unknown>) =>
+export const mergeConfig = (base: Schema.JsonObject, override: Schema.JsonObject) =>
   Effect.try({
     catch: (cause) => new FailedToMergeConfig({ cause }),
     try: () => defu(base, override),

--- a/src/lib/workspace/oxfmt-config.ts
+++ b/src/lib/workspace/oxfmt-config.ts
@@ -1,4 +1,5 @@
-import { isJsonObject, serializeTsObjectLiteral } from "#lib/shared/json.ts"
+import * as Predicate from "effect/Predicate"
+import { serializeTsObjectLiteral } from "#lib/shared/json.ts"
 
 const NESTED_MERGE_KEYS = new Set(["sortImports", "sortPackageJson", "sortTailwindcss"])
 
@@ -24,7 +25,7 @@ function serializeNestedMergeEntry(key: string, value: Record<string, unknown>):
 
 export function toOxfmtTsConfigContent(config: Record<string, unknown> = {}) {
   const configEntries = Object.entries(config).map(([key, value]) => {
-    if (NESTED_MERGE_KEYS.has(key) && isJsonObject(value)) {
+    if (NESTED_MERGE_KEYS.has(key) && Predicate.isObject(value)) {
       return serializeNestedMergeEntry(key, value)
     }
 

--- a/src/lib/workspace/oxlint-config.ts
+++ b/src/lib/workspace/oxlint-config.ts
@@ -1,4 +1,5 @@
 import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
 import { print as printAst } from "esrap"
 import ts from "esrap/languages/ts"
 import {
@@ -9,7 +10,6 @@ import {
   type Program,
   type PropertyKey,
 } from "oxc-parser"
-import { isJsonObject } from "#lib/shared/json.ts"
 
 const REQUIRED_BOOLEAN_OPTIONS = [
   "respectEslintDisableDirectives",
@@ -65,7 +65,7 @@ export function toOxlintTsConfigContent(
   ]
 
   const serializedOptions = JSON.stringify(
-    isJsonObject(options)
+    Predicate.isObject(options)
       ? {
           ...options,
           respectEslintDisableDirectives: true,
@@ -93,14 +93,6 @@ export function toOxlintTsConfigContent(
     .join("\n")
 
   return [...imports, "", "export default defineConfig({", body, "})", ""].join("\n")
-}
-
-function isObjectExpression(value: unknown): value is ObjectExpression {
-  return isJsonObject(value) && value.type === "ObjectExpression" && Array.isArray(value.properties)
-}
-
-function isObjectProperty(value: unknown): value is ObjectProperty {
-  return isJsonObject(value) && value.type === "Property"
 }
 
 const parseThrowable = Option.liftThrowable((content: string) =>
@@ -155,7 +147,7 @@ function getExportedConfigObject(ast: Program) {
 
   const declaration = exportDefaultDeclaration.declaration
 
-  if (isObjectExpression(declaration)) {
+  if (declaration.type === "ObjectExpression") {
     return Option.fromNullishOr(declaration)
   }
 
@@ -173,7 +165,7 @@ function getExportedConfigObject(ast: Program) {
 
   const [firstArgument] = declaration.arguments
 
-  if (isObjectExpression(firstArgument)) {
+  if (firstArgument?.type === "ObjectExpression") {
     return Option.fromNullishOr(firstArgument)
   }
 
@@ -188,10 +180,6 @@ function getNamedObjectProperty(
 
   for (const property of objectExpression.properties) {
     if (property.type === "SpreadElement") {
-      return { status: "manual" }
-    }
-
-    if (!isObjectProperty(property)) {
       return { status: "manual" }
     }
 
@@ -248,11 +236,13 @@ function createRequiredOptionProperties(options: readonly RequiredBooleanOption[
     return Option.none()
   }
 
-  if (!isObjectExpression(optionsPropertyResult.property.value)) {
+  if (optionsPropertyResult.property.value.type !== "ObjectExpression") {
     return Option.none()
   }
 
-  const properties = optionsPropertyResult.property.value.properties.filter(isObjectProperty)
+  const properties = optionsPropertyResult.property.value.properties.filter(
+    (property): property is ObjectProperty => property.type === "Property"
+  )
 
   return properties.length === optionsPropertyResult.property.value.properties.length
     ? Option.fromNullishOr(properties)
@@ -279,8 +269,7 @@ function createRequiredOptionsProperty() {
   const [property] = configObjectExpression.value.properties
 
   if (
-    !property ||
-    !isObjectProperty(property) ||
+    property?.type !== "Property" ||
     property.computed ||
     property.method ||
     property.kind !== "init"
@@ -398,7 +387,7 @@ export function inspectRequiredOxlintConfig(content: string) {
     } satisfies OxlintRequiredOptionsPatchResult
   }
 
-  if (!isObjectExpression(optionsPropertyResult.property.value)) {
+  if (optionsPropertyResult.property.value.type !== "ObjectExpression") {
     return {
       kind: "manual",
       reason: UNSUPPORTED_OPTIONS_REASON,

--- a/src/lib/workspace/tsconfig.ts
+++ b/src/lib/workspace/tsconfig.ts
@@ -1,9 +1,10 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import { defineIntegration } from "#lib/integrations/base.ts"
 import { FailedToReadFile, FailedToWriteFile, InvalidConfigFormat } from "#lib/shared/errors.ts"
-import { isJsonObject, mergeConfig, parseJson } from "#lib/shared/json.ts"
+import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: "tsconfig.json", type: "config" }] as const
 const CONFIG = { extends: "adamantite/typescript" }
@@ -41,7 +42,7 @@ export default defineIntegration({
         .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: configPath })))
       const existingConfig = yield* parseJson(tsconfigFile, configPath)
 
-      if (!isJsonObject(existingConfig)) {
+      if (!Predicate.isObject(existingConfig)) {
         return yield* new InvalidConfigFormat({ path: configPath })
       }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true
   },
   "include": ["src", "presets/**/*.ts", "oxlint.config.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": [".packref", "dist", "node_modules"]
 }


### PR DESCRIPTION
Bumps GitHub Actions workflow versions (`actions/checkout`, `actions/setup-node`, `actions/cache`) and Node.js to current releases, and adds a test that enforces generated workflows stay in sync with the repository's own CI workflow.

Fixes repeated Zed editor setup producing duplicate formatter entries by introducing a `deduplicateConfigArrays` utility that recursively removes structurally equal entries from nested arrays after merging. Idempotency tests for both Zed and VS Code editor integrations are added to cover this behavior.

Replaces the local `isJsonObject` helper with `Predicate.isObject` from Effect throughout the codebase, and removes the now-redundant `isObjectExpression`/`isObjectProperty` wrapper functions in the oxlint config module in favor of direct `.type` property checks.

Switches the source reference workflow from a `.repos` checkout to [Packref](https://github.com/adelrodriguez/packref), updating `.gitignore` and `tsconfig.json` accordingly, and documents the convention in `AGENTS.md`.