### PR TITLE
Remove default analysis preset ignores

### DIFF
--- a/.changeset/late-heads-burn.md
+++ b/.changeset/late-heads-burn.md
@@ -2,4 +2,4 @@
 "adamantite": patch
 ---
 
-Remove default file exclusions from the analysis preset.
+Remove the default file exclusions from the analysis preset. The preset no longer sets `ignore: ["**/*.d.ts"]` or `ignoreFiles: ["**/dist/**", "**/build/**", "**/coverage/**", "**/.next/**", "**/.vercel/**", "**/.turbo/**"]`, so each project now declares the exclusions that match its own structure. Knip already honors `.gitignore`, so the build-output globs were mostly redundant; the change that can surface new `files` errors is the loss of `**/*.d.ts`, which affects projects with committed declaration files such as `vite-env.d.ts`. To keep the previous behavior, add the keys back in your own `knip.config.ts` after the `...analyze` spread.

--- a/.changeset/late-heads-burn.md
+++ b/.changeset/late-heads-burn.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Remove default file exclusions from the analysis preset.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -5,7 +5,6 @@ export default {
   ...analyze,
   entry: ["presets/**/*.ts"],
   ignore: ["bunup.config.ts"],
-  ignoreFiles: [],
   rules: {
     ...analyze.rules,
     devDependencies: "off",

--- a/presets/analyze.ts
+++ b/presets/analyze.ts
@@ -1,16 +1,7 @@
 import type { KnipConfiguration } from "knip"
 
 const config: KnipConfiguration = {
-  ignore: ["**/*.d.ts"],
   ignoreExportsUsedInFile: true,
-  ignoreFiles: [
-    "**/dist/**",
-    "**/build/**",
-    "**/coverage/**",
-    "**/.next/**",
-    "**/.vercel/**",
-    "**/.turbo/**",
-  ],
   rules: {
     binaries: "error",
     catalog: "error",


### PR DESCRIPTION
## Why?

The published analysis preset should not hide generated or declaration files for every target project. Each target project must choose the exclusions that match its own structure.

This removes `ignore` and `ignoreFiles` from the preset. Adamantite keeps its required `bunup.config.ts` exclusion in its local `knip.config.ts`.

## Validation

- `bun run fix`
- `bun run format`
- `bun run test` (285 tests passed)
- `bun run check`
- `bun run analyze`
