### PR TITLE
Skip root tsconfig setup in monorepos and preserve existing extends

### DIFF
--- a/.changeset/plain-woods-guide.md
+++ b/.changeset/plain-woods-guide.md
@@ -1,5 +1,5 @@
 ---
-"adamantite": patch
+"adamantite": minor
 ---
 
 Skip root `tsconfig.json` creation and updates during `init` in a detected monorepo. A catch-all root config makes TypeScript treat all workspace packages as one project and can try to emit over JavaScript input files. In a monorepo, `init --typescript` now prints guidance to add `"extends": "adamantite/typescript"` to each package's `tsconfig.json` or to a shared base config, and does not change any files.

--- a/.changeset/plain-woods-guide.md
+++ b/.changeset/plain-woods-guide.md
@@ -1,0 +1,9 @@
+---
+"adamantite": patch
+---
+
+Skip root `tsconfig.json` creation and updates during `init` in a detected monorepo. A catch-all root config makes TypeScript treat all workspace packages as one project and can try to emit over JavaScript input files. In a monorepo, `init --typescript` now prints guidance to add `"extends": "adamantite/typescript"` to each package's `tsconfig.json` or to a shared base config, and does not change any files.
+
+Stop overwriting an existing `extends` value when `init` updates a `tsconfig.json`. Adamantite now appends `"adamantite/typescript"` to the `extends` array instead, so a shared base config such as `"@company/tsconfig"` stays in place. The preset is appended last, so its compiler options override the earlier entries.
+
+The `adamantite/typescript` preset now sets `"noEmit": true`, so projects that extend it type-check without emitting output. If your project emits output with `tsc` through the preset, set `"noEmit": false` in your own `tsconfig.json`.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Presets and TypeScript require the `check` or `fix` script. Editor extension ins
 requires an editor. Monorepo scripts require a detected monorepo. GitHub Actions requires a
 compatible script and a supported package manager. Omitted boolean flags are disabled.
 
+In a detected monorepo, TypeScript setup does not write a root `tsconfig.json`, because a
+catch-all root config makes TypeScript treat all packages as one project. Adamantite
+prints guidance instead: add `"extends": "adamantite/typescript"` to each package's
+`tsconfig.json` or to a shared base config.
+
 ## Commands
 
 Run `adamantite --help` or `adamantite <command> --help` for the complete CLI reference.

--- a/presets/tsconfig.json
+++ b/presets/tsconfig.json
@@ -8,6 +8,10 @@
     "resolveJsonModule": true,
     "moduleDetection": "force",
 
+    // The preset is a type-checking base. Set "noEmit": false in your project
+    // if you emit output with tsc.
+    "noEmit": true,
+
     // Strictness and best practices. We only recommend settings that are not
     // covered by linting rules.
     "strict": true,

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -298,6 +298,96 @@ describe("init", () => {
     })
   })
 
+  describe("monorepo TypeScript setup", () => {
+    const monorepoGuidanceLogs = [
+      {
+        level: "info",
+        message:
+          "Skipping `tsconfig.json` setup: a root config in a monorepo makes TypeScript treat all packages as one project.",
+      },
+      {
+        level: "info",
+        message:
+          'To use the TypeScript preset, add `"extends": "adamantite/typescript"` to each package\'s `tsconfig.json` or to a shared base config.',
+      },
+    ] as const
+
+    beforeEach(async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test-project",
+            version: "1.0.0",
+            workspaces: ["packages/*"],
+          },
+          null,
+          2
+        )
+      )
+    })
+
+    test("print guidance instead of creating a root tsconfig in a monorepo", async () => {
+      const prompter = createPrompterTestContext({
+        confirmResponses: [true, false, false],
+        multiselectResponses: [["check"], [], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(await Bun.file(join(tempDir, "tsconfig.json")).exists()).toBe(false)
+
+      for (const log of monorepoGuidanceLogs) {
+        expect(prompter.logs).toContainEqual(log)
+      }
+    })
+
+    test("print guidance instead of creating a root tsconfig in non-interactive mode", async () => {
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(
+        initCommand,
+        ["--non-interactive", "--script", "check", "--typescript"],
+        [prompter.layer, installer.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(await Bun.file(join(tempDir, "tsconfig.json")).exists()).toBe(false)
+
+      for (const log of monorepoGuidanceLogs) {
+        expect(prompter.logs).toContainEqual(log)
+      }
+    })
+
+    test("leave an existing root tsconfig unchanged in a monorepo", async () => {
+      const existingTsconfig = JSON.stringify(
+        {
+          extends: "./tooling/tsconfig.base.json",
+          files: [],
+          references: [{ path: "packages/app" }],
+        },
+        null,
+        2
+      )
+      await writeFile(join(tempDir, "tsconfig.json"), existingTsconfig)
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(
+        initCommand,
+        ["--non-interactive", "--script", "check", "--typescript"],
+        [prompter.layer, installer.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(await readFile(join(tempDir, "tsconfig.json"), "utf8")).toBe(existingTsconfig)
+    })
+  })
+
   describe("existing config updates", () => {
     test("update existing configs without dropping preserved user settings", async () => {
       const originalOxfmtConfig = [

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -137,9 +137,20 @@ const addScripts = (cwd: string, scripts: Script[]) =>
     )
   })
 
-const setupTypescript = (cwd: string) =>
+const setupTypescript = (cwd: string, isMonorepo: boolean) =>
   Effect.gen(function* () {
     const prompter = yield* Prompter
+
+    if (isMonorepo) {
+      yield* prompter.log.info(
+        "Skipping `tsconfig.json` setup: a root config in a monorepo makes TypeScript treat all packages as one project."
+      )
+      yield* prompter.log.info(
+        'To use the TypeScript preset, add `"extends": "adamantite/typescript"` to each package\'s `tsconfig.json` or to a shared base config.'
+      )
+      return
+    }
+
     yield* prompter.withSpinner(
       (spinner) =>
         Effect.gen(function* () {
@@ -723,7 +734,7 @@ export default Command.make("init", {
       }
 
       if (shouldSetupTypescript) {
-        yield* setupTypescript(cwd)
+        yield* setupTypescript(cwd, isMonorepo)
       }
 
       yield* setupEditors(cwd, selectedEditors)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -546,8 +546,9 @@ const collectInteractiveInitOptions = Effect.fn("collectInteractiveInitOptions")
   const shouldSetupTypescript = hasOxlint
     ? yield* prompter.confirm({
         initialValue: true,
-        message:
-          "Adamantite provides a TypeScript preset to enforce strict type-safety. Would you like to use it?",
+        message: isMonorepo
+          ? "Adamantite provides a TypeScript preset to enforce strict type-safety. In a monorepo, each package's `tsconfig.json` must extend it. Would you like instructions on how to set it up?"
+          : "Adamantite provides a TypeScript preset to enforce strict type-safety. Would you like to use it?",
       })
     : false
 

--- a/src/lib/workspace/__tests__/tsconfig.test.ts
+++ b/src/lib/workspace/__tests__/tsconfig.test.ts
@@ -97,7 +97,7 @@ describe("tsconfig", () => {
       expect(config.extends).toBe("adamantite/typescript")
     })
 
-    test("preserve the rest of the config when updating extends", async () => {
+    test("append the preset to an existing extends string instead of overwriting it", async () => {
       await Bun.write(
         "tsconfig.json",
         JSON.stringify(
@@ -117,8 +117,54 @@ describe("tsconfig", () => {
       const content = await Bun.file("tsconfig.json").text()
       const config = JSON.parse(content)
 
-      expect(config.extends).toBe("adamantite/typescript")
+      expect(config.extends).toEqual(["@company/tsconfig", "adamantite/typescript"])
       expect(config.compilerOptions).toEqual({ target: "ES2020" })
+    })
+
+    test("keep extends as a string when it is already the preset", async () => {
+      await Bun.write(
+        "tsconfig.json",
+        JSON.stringify({ extends: "adamantite/typescript" }, null, 2)
+      )
+
+      await tsconfig.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file("tsconfig.json").text()
+      const config = JSON.parse(content)
+
+      expect(config.extends).toBe("adamantite/typescript")
+    })
+
+    test("append the preset to an existing extends array", async () => {
+      await Bun.write(
+        "tsconfig.json",
+        JSON.stringify({ extends: ["@company/tsconfig", "@company/tsconfig-strict"] }, null, 2)
+      )
+
+      await tsconfig.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file("tsconfig.json").text()
+      const config = JSON.parse(content)
+
+      expect(config.extends).toEqual([
+        "@company/tsconfig",
+        "@company/tsconfig-strict",
+        "adamantite/typescript",
+      ])
+    })
+
+    test("leave an extends array unchanged when it already contains the preset", async () => {
+      await Bun.write(
+        "tsconfig.json",
+        JSON.stringify({ extends: ["adamantite/typescript", "@company/tsconfig"] }, null, 2)
+      )
+
+      await tsconfig.update(tempDir).pipe(Effect.provide(NodeServices.layer), Effect.runPromise)
+
+      const content = await Bun.file("tsconfig.json").text()
+      const config = JSON.parse(content)
+
+      expect(config.extends).toEqual(["adamantite/typescript", "@company/tsconfig"])
     })
 
     test("merge an empty config with Adamantite's config", async () => {

--- a/src/lib/workspace/tsconfig.ts
+++ b/src/lib/workspace/tsconfig.ts
@@ -11,8 +11,9 @@ const files = [{ path: "tsconfig.json", type: "config" }] as const
 const PRESET_EXTENDS = "adamantite/typescript"
 const CONFIG = { extends: PRESET_EXTENDS }
 
-// Later entries in an `extends` array override earlier ones, so appending the
-// preset preserves the existing base while the preset's options win.
+// Later entries in an `extends` array override earlier ones, so the preset is
+// appended last when Adamantite adds it. An array that already contains the
+// preset is kept in the user's order, even when the preset is not last.
 function mergeExtends(existing: unknown) {
   if (Predicate.isString(existing)) {
     return existing === PRESET_EXTENDS ? existing : [existing, PRESET_EXTENDS]

--- a/src/lib/workspace/tsconfig.ts
+++ b/src/lib/workspace/tsconfig.ts
@@ -1,3 +1,4 @@
+import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
@@ -7,7 +8,22 @@ import { FailedToReadFile, FailedToWriteFile, InvalidConfigFormat } from "#lib/s
 import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: "tsconfig.json", type: "config" }] as const
-const CONFIG = { extends: "adamantite/typescript" }
+const PRESET_EXTENDS = "adamantite/typescript"
+const CONFIG = { extends: PRESET_EXTENDS }
+
+// Later entries in an `extends` array override earlier ones, so appending the
+// preset preserves the existing base while the preset's options win.
+function mergeExtends(existing: unknown) {
+  if (Predicate.isString(existing)) {
+    return existing === PRESET_EXTENDS ? existing : [existing, PRESET_EXTENDS]
+  }
+
+  if (Array.isArray(existing)) {
+    return existing.includes(PRESET_EXTENDS) ? existing : [...existing, PRESET_EXTENDS]
+  }
+
+  return PRESET_EXTENDS
+}
 
 export default defineIntegration({
   config: files[0].path,
@@ -46,7 +62,11 @@ export default defineIntegration({
         return yield* new InvalidConfigFormat({ path: configPath })
       }
 
-      const newConfig = yield* mergeConfig(CONFIG, existingConfig)
+      const merged = yield* mergeConfig(CONFIG, existingConfig)
+      const newConfig = {
+        ...merged,
+        extends: mergeExtends("extends" in existingConfig ? existingConfig.extends : undefined),
+      }
 
       yield* fs
         .writeFileString(configPath, `${JSON.stringify(newConfig, null, 2)}\n`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "allowImportingTsExtensions": true,
-    "types": ["bun"],
-    "noEmit": true
+    "types": ["bun"]
   },
   "include": ["src", "presets/**/*.ts", "oxlint.config.ts"],
   "exclude": [".packref", "dist", "node_modules"]


### PR DESCRIPTION
Fixes #359

## Problem

In a TypeScript monorepo without a root `tsconfig.json`, `init --typescript` wrote `{ "extends": "adamantite/typescript" }` at the root. With no `files`/`include` scoping, TypeScript treats the whole repository as one project, and because the preset enables `allowJs` without `noEmit`, `adamantite check` fails with `Cannot write file ... because it would overwrite input file`. `init` already detected the monorepo but never passed that knowledge to the TypeScript setup.

## Changes

- **Monorepo guidance instead of file writes.** `setupTypescript` now receives `isMonorepo`. In a detected monorepo it changes no files and prints guidance: add `"extends": "adamantite/typescript"` to each package's `tsconfig.json` or to a shared base config. This applies to interactive and `--non-interactive` runs alike. The interactive confirm is reworded in a monorepo to offer instructions rather than implying a root config will be written.
- **`noEmit` in the preset.** `adamantite/typescript` now sets `"noEmit": true`, which fixes the emit-over-input error class everywhere (including single-package projects with root JS config files) and reaches existing projects on upgrade with no migration. Consumers that emit with `tsc` through the preset opt back out with `"noEmit": false`. The repo's own root `tsconfig.json` drops its now-redundant override. Verified on TypeScript 7.0.2 that `"composite": true` merged with the preset's `noEmit` is accepted (exit 0, no emit besides `.tsbuildinfo`) — the ≤5.x TS5053 hard error does not apply to any supported consumer, since the peer dependency requires TS 7+.
- **Preserve existing `extends`.** `tsconfig.update` previously overwrote a user's `extends` (for example a shared `"@company/tsconfig"`) via the defu merge. It now appends `"adamantite/typescript"` to the `extends` array instead, idempotently. When Adamantite adds the preset it goes last, so its compiler options win over earlier entries; an array that already contains the preset keeps the user's order.

## Tests

- Three new `init` cases: interactive and non-interactive monorepo runs print guidance and write no root `tsconfig.json`; an existing solution-style root config is left byte-for-byte unchanged.
- Updated the tsconfig integration test that asserted the `extends` overwrite, plus three new cases for the append behavior and idempotency.
- Verified end-to-end against the issue's reproduction: `init --non-interactive --script check --typescript` in a workspace fixture prints guidance, creates no root config, and exits 0.
- `bun run test` (291 pass), `check`, `format --check`, `analyze`, and `build` are all clean.

## Versioning

The changeset is `minor`: the preset's new `noEmit` changes compiler behavior for every consumer automatically within the current range.

## Out of scope

- #362 — the `legacy-typecheck-script` migration still calls `tsconfig.create`/`update` unconditionally, so that legacy path (reachable from `adamantite update` and `doctor --fix`) can still write a root config in a monorepo.
- Already-initialized monorepos keep their broken root `tsconfig.json`; deleting it manually is the fix (nothing in `doctor` manages the tsconfig integration today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)