### PR TITLE
Show error causes in CLI failure messages

### DIFF
--- a/.changeset/shiny-hounds-report.md
+++ b/.changeset/shiny-hounds-report.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Show the captured package manager output when dependency installation fails during `init`. The error message now includes the underlying diagnostic, for example `ERR_PNPM_UNSUPPORTED_ENGINE`, instead of only the package list.

--- a/.changeset/tidy-panthers-speak.md
+++ b/.changeset/tidy-panthers-speak.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Include the underlying cause in file-system and extension error messages. Failed read, write, delete, and directory-creation operations now show the platform error detail, and a failed VS Code extension install reports the `code` CLI exit code.

--- a/docs/plans/verbose-flag.md
+++ b/docs/plans/verbose-flag.md
@@ -1,0 +1,95 @@
+# Plan: verbose flag for full diagnostics
+
+## Goal
+
+Add a `--verbose` flag to the Adamantite CLI. The default error output stays concise but
+complete: a summary line plus the trimmed failure reason. The verbose mode adds the full
+diagnostic depth that the default output truncates or omits.
+
+## Background
+
+Issue #357 showed that `init` hid the package-manager error. The fix shows the failure
+cause by default, with two limits that keep the terminal output readable:
+
+- `formatCauseOutput` in `src/lib/shared/errors.ts` caps multi-line cause output at the
+  last 20 lines (`MAX_CAUSE_OUTPUT_LINES`).
+- `formatCauseDetail` in the same file keeps only the first line of a cause message.
+
+The verbose flag removes these limits and adds diagnostics that are noise on the default
+path. It must not change the default behavior.
+
+## What verbose mode unlocks
+
+1. **Untruncated cause output.** Print the full captured package-manager output, not the
+   last 20 lines. Print all lines of a cause message, not the first line.
+2. **The full cause chain.** Walk `error.cause` recursively and print each nested cause.
+3. **Stack traces.** Print `error.stack` for the failure and its causes.
+4. **Defect rendering.** Render unexpected defects with `Cause.pretty` instead of the
+   default runtime output.
+5. **Command echo.** `CommandRunner` and `DependencyInstaller` log the exact command and
+   arguments before each run.
+
+## Design
+
+### Verbosity service
+
+Add a `Verbosity` service in `src/lib/services/verbosity.ts` with a default value of
+`false`. Use a `Context.Reference`-style service so consumers do not need explicit
+provision in tests. Message getters on error classes stay pure and context-free; they
+cannot read a flag. Apply verbosity only at the effect edges:
+
+- The top-level error handler in `src/index.ts`. Default: print `error.message` (current
+  behavior). Verbose: catch the full `Cause` (`Effect.catchCause` instead of
+  `Effect.catch`) and render it with `Cause.pretty`. `Cause.pretty` natively renders the
+  error name and message, cleaned stack traces with span annotations, and the nested
+  `error.cause` chain with indentation. Do not hand-roll cause-chain walking or stack
+  formatting. If per-line control is needed for the clack gutter, build the output from
+  `Cause.prettyErrors` instead, which returns the individual `Error` instances.
+- `CommandRunner.run` and `DependencyInstaller.addDevDependencies`. Verbose: log the
+  command before execution.
+
+### Flag wiring
+
+- Declare `Flag.boolean("verbose")` on the root command in `src/cli.ts` so the flag
+  appears in `--help`. Invocation form: `adamantite --verbose <command>`.
+- Also read the raw arguments in `src/index.ts` before CLI parsing and accept
+  `--verbose` in any position, including `adamantite <command> --verbose`. Provide the
+  `Verbosity` service to the whole program from this scan. The pre-scan is required
+  because the top-level error handler runs outside command parsing, and because
+  subcommands do not inherit root flags.
+- Exclude arguments after the `--` separator from the pre-scan. Those arguments belong
+  to the underlying tool (see `runCli` passthrough handling).
+- Accept `ADAMANTITE_VERBOSE=1` as an environment fallback for CI, where editing the
+  invocation is harder than setting an environment variable.
+
+### Formatting rules
+
+Verbose output goes through the same clack logger as the default output, so every line
+keeps the gutter prefix. Reuse the sanitization from `formatCauseOutput` (strip ANSI
+codes, treat carriage returns as line breaks, drop blank lines) and export an
+untruncated variant instead of duplicating the logic.
+
+## Steps
+
+1. Add the `Verbosity` service with a `false` default.
+2. Export an untruncated formatter from `src/lib/shared/errors.ts` that shares the
+   sanitization helpers.
+3. Add the raw-argument pre-scan and the environment fallback in `src/index.ts`, and
+   provide the service.
+4. Declare the flag on the root command in `src/cli.ts` for `--help` visibility.
+5. Extend the top-level error handler with the verbose rendering path built on
+   `Cause.pretty` or `Cause.prettyErrors`.
+6. Add command echo to `CommandRunner` and `DependencyInstaller`.
+7. Tests: pre-scan positions, `--` exclusion, environment fallback, verbose error
+   rendering, unchanged default output.
+8. Add a minor changeset and update the README flag documentation.
+
+## Out of scope
+
+- Log levels beyond a boolean (`-v`, `-vv`).
+- Verbose output for the underlying tools themselves (oxlint, oxfmt, knip). Passthrough
+  arguments after `--` already cover that need.
+
+## Completion
+
+Delete this file when the work is complete.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -5,7 +5,10 @@ import {
   CliNotFound,
   CommandFailed,
   FailedToInstallDependency,
+  FailedToInstallExtension,
   FailedToParseFile,
+  FailedToReadFile,
+  FailedToWriteFile,
   FileNotFound,
 } from "#lib/shared/errors.ts"
 
@@ -66,6 +69,98 @@ describe("errors", () => {
       const error = new FailedToInstallDependency({})
 
       expect(error.message).toBe("Failed to install dependencies.")
+    })
+
+    test("include the package manager output from the cause", () => {
+      const cause = new Error(
+        [
+          "`pnpm add -D adamantite` failed.",
+          "",
+          " ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)",
+          'Your Node version is incompatible with "adamantite@0.34.4".',
+          "Expected version: >=24",
+          "Got: v22.22.0",
+        ].join("\n")
+      )
+      const error = new FailedToInstallDependency({ cause, packages: ["adamantite"] })
+
+      expect(error.message).toContain("Failed to install dependencies: adamantite.")
+      expect(error.message).toContain("ERR_PNPM_UNSUPPORTED_ENGINE")
+      expect(error.message).toContain("Expected version: >=24")
+      expect(error.message).not.toContain("\n\n")
+    })
+
+    test("strip ANSI escape codes and carriage returns from the cause output", () => {
+      const cause = new Error("\u001B[31mERR_PNPM_FETCH_404\u001B[39m\rretrying...\r\ndone")
+      const error = new FailedToInstallDependency({ cause })
+
+      expect(error.message).toContain("ERR_PNPM_FETCH_404")
+      expect(error.message).toContain("retrying...")
+      expect(error.message).not.toContain("\u001B")
+      expect(error.message).not.toContain("\r")
+    })
+
+    test("truncate long cause output to the last 20 lines", () => {
+      const lines = Array.from({ length: 30 }, (_, index) => `line ${index + 1}`)
+      const cause = new Error(lines.join("\n"))
+      const error = new FailedToInstallDependency({ cause })
+
+      expect(error.message).toContain("…")
+      expect(error.message).toContain("line 30")
+      expect(error.message).toContain("line 11")
+      expect(error.message).not.toContain("line 10\n")
+    })
+
+    test("ignore causes that are not Error instances", () => {
+      const error = new FailedToInstallDependency({ cause: "boom" })
+
+      expect(error.message).toBe("Failed to install dependencies.")
+    })
+  })
+
+  describe("FailedToWriteFile", () => {
+    test("include the cause detail when the cause is an Error", () => {
+      const cause = new Error("PermissionDenied: FileSystem.writeFile (/repo/oxlint.json)")
+      const error = new FailedToWriteFile({ cause, path: "/repo/oxlint.json" })
+
+      expect(error.message).toBe(
+        "Failed to write `/repo/oxlint.json`. Cause: PermissionDenied: FileSystem.writeFile (/repo/oxlint.json)"
+      )
+    })
+
+    test("keep only the first line of a multi-line cause", () => {
+      const cause = new Error("first line\nsecond line")
+      const error = new FailedToWriteFile({ cause, path: "/repo/oxlint.json" })
+
+      expect(error.message).toContain("Cause: first line")
+      expect(error.message).not.toContain("second line")
+    })
+  })
+
+  describe("FailedToReadFile", () => {
+    test("fall back to a plain message when the cause is missing", () => {
+      const error = new FailedToReadFile({ path: "/repo/tsconfig.json" })
+
+      expect(error.message).toBe("Failed to read `/repo/tsconfig.json`.")
+    })
+  })
+
+  describe("FailedToInstallExtension", () => {
+    test("report the exit code when the cause is a number", () => {
+      const error = new FailedToInstallExtension({ cause: 1, extension: "oxc.oxc-vscode" })
+
+      expect(error.message).toBe(
+        "Failed to install `oxc.oxc-vscode`. The `code` CLI exited with code 1."
+      )
+    })
+
+    test("include the cause detail when the cause is an Error", () => {
+      const cause = new Error("SystemError: spawn code EAGAIN")
+      const error = new FailedToInstallExtension({ cause, extension: "oxc.oxc-vscode" })
+
+      expect(error.message).toBe(
+        "Failed to install `oxc.oxc-vscode`. Cause: SystemError: spawn code EAGAIN"
+      )
     })
   })
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -124,7 +124,16 @@ describe("errors", () => {
       const error = new FailedToWriteFile({ cause, path: "/repo/oxlint.json" })
 
       expect(error.message).toBe(
-        "Failed to write `/repo/oxlint.json`. Cause: PermissionDenied: FileSystem.writeFile (/repo/oxlint.json)"
+        "Failed to write `/repo/oxlint.json`. Cause: PermissionDenied: FileSystem.writeFile (/repo/oxlint.json)."
+      )
+    })
+
+    test("do not double the period when the cause already ends with one", () => {
+      const cause = new Error("Something went wrong.")
+      const error = new FailedToWriteFile({ cause, path: "/repo/oxlint.json" })
+
+      expect(error.message).toBe(
+        "Failed to write `/repo/oxlint.json`. Cause: Something went wrong."
       )
     })
 
@@ -159,7 +168,7 @@ describe("errors", () => {
       const error = new FailedToInstallExtension({ cause, extension: "oxc.oxc-vscode" })
 
       expect(error.message).toBe(
-        "Failed to install `oxc.oxc-vscode`. Cause: SystemError: spawn code EAGAIN"
+        "Failed to install `oxc.oxc-vscode`. Cause: SystemError: spawn code EAGAIN."
       )
     })
   })

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -988,6 +988,39 @@ describe("init", () => {
       expect(installer.calls).toEqual([])
     })
 
+    test("continue successfully and show the exit code when the extension install fails", async () => {
+      const prompter = createPrompterTestContext({
+        confirmResponses: [true, false, false],
+        multiselectResponses: [["format"], ["vscode"]],
+      })
+      const installer = createDependencyInstallerTestContext()
+      const runner = createRunnerTestContext({
+        implementation: (options) =>
+          Effect.succeed(ChildProcessSpawner.ExitCode(options.command === "code" ? 1 : 0)),
+      })
+
+      const exit = await runCommand(
+        initCommand,
+        [],
+        [prompter.layer, installer.layer, runner.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message: "⚠️ Failed to install `oxc.oxc-vscode`. The `code` CLI exited with code 1.",
+      })
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message: "Please install it manually after setup completes.",
+      })
+      expect(prompter.logs).toContainEqual({
+        level: "success",
+        message: "Your project is now configured",
+      })
+    })
+
     test("continue successfully and show guidance when the VS Code CLI is unavailable", async () => {
       const prompter = createPrompterTestContext({
         confirmResponses: [true, false, false],

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -795,7 +795,7 @@ describe("init", () => {
       expect(prompter.logs).toContainEqual({
         level: "warning",
         message: expect.stringMatching(
-          /Could not update AGENTS\.md\. Failed to read `.*\/AGENTS\.md`\. Adamantite will continue initialization\./
+          /Could not update AGENTS\.md\. Failed to read `.*\/AGENTS\.md`\.( Cause: .*)? Adamantite will continue initialization\./
         ),
       })
       expect(prompter.logs).toContainEqual({

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -238,9 +238,7 @@ const installEditorExtensions = (editors: string[], scripts: Script[]) =>
       .pipe(
         Effect.catchTag("FailedToInstallExtension", (error) =>
           Effect.gen(function* () {
-            yield* prompter.log.warning(
-              `⚠️ Failed to install the \`${error.extension}\` extension.`
-            )
+            yield* prompter.log.warning(`⚠️ ${error.message}`)
             yield* prompter.log.warning("Please install it manually after setup completes.")
             return false as const
           })

--- a/src/lib/shared/errors.ts
+++ b/src/lib/shared/errors.ts
@@ -1,7 +1,48 @@
 import type * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
 import type { ParseError } from "jsonc-parser"
+import { stripVTControlCharacters } from "node:util"
+import * as Array from "effect/Array"
 import * as Data from "effect/Data"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
+import * as String from "effect/String"
 import { printParseErrorCode } from "jsonc-parser"
+
+const MAX_CAUSE_OUTPUT_LINES = 20
+
+function causeLines(cause: unknown) {
+  return Predicate.isError(cause)
+    ? pipe(
+        stripVTControlCharacters(cause.message),
+        String.split(/\r\n|[\r\n]/),
+        Array.map((line) => String.trimEnd(line)),
+        Array.filter((line) => String.isNonEmpty(line))
+      )
+    : []
+}
+
+function formatCauseDetail(cause: unknown) {
+  return pipe(
+    causeLines(cause),
+    Array.head,
+    Option.map((line) => ` Cause: ${String.trim(line)}`),
+    Option.getOrElse(() => "")
+  )
+}
+
+function formatCauseOutput(cause: unknown) {
+  const lines = causeLines(cause)
+
+  if (!Array.isReadonlyArrayNonEmpty(lines)) {
+    return ""
+  }
+
+  const tail = Array.takeRight(lines, MAX_CAUSE_OUTPUT_LINES)
+  const shown = tail.length < lines.length ? ["…", ...tail] : tail
+
+  return `\n${shown.join("\n")}`
+}
 
 function formatParseErrors(errors: ParseError[] = []) {
   if (errors.length === 0) {
@@ -35,7 +76,7 @@ export class FailedToCreateDirectory extends Data.TaggedError("FailedToCreateDir
 }> {
   override get message() {
     const target = this.path ? `\`${this.path}\`` : "the target directory"
-    return `Failed to create directory ${target}.`
+    return `Failed to create directory ${target}.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -45,7 +86,7 @@ export class FailedToInstallDependency extends Data.TaggedError("FailedToInstall
 }> {
   override get message() {
     const target = this.packages?.length ? `: ${this.packages.join(", ")}` : ""
-    return `Failed to install dependencies${target}.`
+    return `Failed to install dependencies${target}.${formatCauseOutput(this.cause)}`
   }
 }
 
@@ -55,7 +96,12 @@ export class FailedToInstallExtension extends Data.TaggedError("FailedToInstallE
 }> {
   override get message() {
     const target = this.extension ? `\`${this.extension}\`` : "the target extension"
-    return `Failed to install ${target}.`
+
+    if (Predicate.isNumber(this.cause)) {
+      return `Failed to install ${target}. The \`code\` CLI exited with code ${this.cause}.`
+    }
+
+    return `Failed to install ${target}.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -63,8 +109,7 @@ export class FailedToMergeConfig extends Data.TaggedError("FailedToMergeConfig")
   cause?: unknown
 }> {
   override get message() {
-    const detail = this.cause instanceof Error ? ` Cause: ${this.cause.message}` : ""
-    return `Failed to merge configuration.${detail}`
+    return `Failed to merge configuration.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -91,7 +136,7 @@ export class FailedToReadFile extends Data.TaggedError("FailedToReadFile")<{
 }> {
   override get message() {
     const target = this.path ? `\`${this.path}\`` : "the target file"
-    return `Failed to read ${target}.`
+    return `Failed to read ${target}.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -101,7 +146,7 @@ export class FailedToDeleteFile extends Data.TaggedError("FailedToDeleteFile")<{
 }> {
   override get message() {
     const target = this.path ? `\`${this.path}\`` : "the target file"
-    return `Failed to delete ${target}.`
+    return `Failed to delete ${target}.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -111,7 +156,7 @@ export class FailedToWriteFile extends Data.TaggedError("FailedToWriteFile")<{
 }> {
   override get message() {
     const target = this.path ? `\`${this.path}\`` : "the target file"
-    return `Failed to write ${target}.`
+    return `Failed to write ${target}.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -155,8 +200,7 @@ export class NoPackageManager extends Data.TaggedError("NoPackageManager")<{
   cause?: unknown
 }> {
   override get message() {
-    const detail = this.cause instanceof Error ? ` Cause: ${this.cause.message}` : ""
-    return `No package manager detected. Please run this command from a project with a lockfile.${detail}`
+    return `No package manager detected. Please run this command from a project with a lockfile.${formatCauseDetail(this.cause)}`
   }
 }
 
@@ -205,7 +249,6 @@ export class VscodeCliNotFound extends Data.TaggedError("VscodeCliNotFound")<{
   cause?: unknown
 }> {
   override get message() {
-    const detail = this.cause instanceof Error ? ` Cause: ${this.cause.message}` : ""
-    return `VS Code CLI (\`code\`) not found. Please install it to manage extensions.${detail}`
+    return `VS Code CLI (\`code\`) not found. Please install it to manage extensions.${formatCauseDetail(this.cause)}`
   }
 }

--- a/src/lib/shared/errors.ts
+++ b/src/lib/shared/errors.ts
@@ -26,7 +26,10 @@ function formatCauseDetail(cause: unknown) {
   return pipe(
     causeLines(cause),
     Array.head,
-    Option.map((line) => ` Cause: ${String.trim(line)}`),
+    Option.map((line) => {
+      const detail = String.trim(line)
+      return /[.!?]$/.test(detail) ? ` Cause: ${detail}` : ` Cause: ${detail}.`
+    }),
     Option.getOrElse(() => "")
   )
 }


### PR DESCRIPTION
## Summary

- show the captured package-manager output when dependency installation fails during `init`, so failures like `ERR_PNPM_UNSUPPORTED_ENGINE` are visible instead of only a package list
- sanitize the output for terminal rendering: strip ANSI codes, treat carriage returns as line breaks, drop blank lines, and cap the output at the last 20 lines
- append the platform error detail to file read, write, delete, and directory-creation failures (for example `PermissionDenied: FileSystem.writeFile (...)`)
- report the `code` CLI exit code when a VS Code extension install fails
- unify the cause formatting in one pair of helpers built with Effect `Predicate`, `String`, `Array`, and `Option` combinators
- add a plan for a future `--verbose` flag that renders full causes with `Cause.pretty`
- add two patch changesets

Fixes #357

## Why

`init` reported only a generic dependency list when its install failed and suppressed the actual package-manager diagnostic. The wrapped error already carried the full stdout and stderr from nypm; the message getter dropped it. The same cause-swallowing shape existed in the file-system and extension errors. The default output stays concise: verbose depth (full cause chains, stack traces) is deliberately out of scope and documented in `docs/plans/verbose-flag.md`.

## Validation

- `bun run test` — 294 tests passed
- `bun run check`
- `bun run fix`
- `bun run format`
- `bun run analyze`
- rendered the failure from #357 through the clack logger and confirmed the gutter formatting holds with ANSI-colored multi-line pnpm output

🤖 Generated with [Claude Code](https://claude.com/claude-code)