### PR TITLE
Apply functional pipeline patterns to shared workspace helpers

### DIFF
--- a/docs/adr/0001-keep-no-array-callback-reference.md
+++ b/docs/adr/0001-keep-no-array-callback-reference.md
@@ -1,0 +1,18 @@
+# Keep unicorn/no-array-callback-reference in the core lint preset
+
+The `unicorn/no-array-callback-reference` rule matches on method names (`.some`, `.map`,
+`.filter`, `.forEach`) without type information, so it reports false positives on Effect
+combinators such as `Option.some(reference)` and `Effect.forEach(data, fn)`. We decided
+(2026-08-13, PR #365) to keep the rule at `"error"` in `presets/lint/core.ts`. The bugs it
+catches — iterator methods that silently pass `(element, index, array)` into a function
+reference, as in `array.map(parseInt)` — are worth the workaround cost.
+
+## Consequences
+
+- Code in this repository, and in target projects that use Effect or similar functional
+  libraries, must satisfy the rule with `pipe(x, Option.some)` in place of
+  `Option.some(reference)`, and the curried data-last `Effect.forEach(fn)` inside
+  `pipe(...)` in place of `Effect.forEach(data, fn)`. See `src/lib/shared/assessment.ts`
+  for the precedent.
+- Removal or downgrade of the rule is a preset behavior change that ships to consumers
+  and requires a changeset.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,3 @@
 # Architecture decision records
 
-No architecture decision records have been accepted yet.
+- [ADR 0001: Keep unicorn/no-array-callback-reference in the core lint preset](0001-keep-no-array-callback-reference.md)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,9 +1,11 @@
 import process from "node:process"
 import type { PackageJson } from "type-fest"
+import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Result from "effect/Result"
 import * as Command from "effect/unstable/cli/Command"
 import type { ToolingPackage } from "#lib/integrations/base.ts"
-import type { Migration, MigrationCheckResult } from "#lib/migrations/base.ts"
 import knip from "#lib/integrations/tooling/knip.ts"
 import oxfmt from "#lib/integrations/tooling/oxfmt.ts"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
@@ -32,27 +34,26 @@ type PackageUpdate = {
   readonly targetVersion: string
 }
 
-function getFallbackPackageUpdates(packageJson: PackageJson, coveredPackages: ReadonlySet<string>) {
-  const updates: PackageUpdate[] = []
-
-  for (const pkg of knownPackages) {
+function getFallbackPackageUpdates(
+  packageJson: PackageJson,
+  coveredPackages: ReadonlySet<string>
+): PackageUpdate[] {
+  return Array.filterMap(knownPackages, (pkg) => {
     if (coveredPackages.has(pkg.name)) {
-      continue
+      return Result.failVoid
     }
 
     const dependency =
       packageJson.devDependencies?.[pkg.name] ?? packageJson.dependencies?.[pkg.name]
 
-    if (dependency && normalizeDependencyVersion(dependency) !== pkg.version) {
-      updates.push({
-        currentVersion: dependency,
-        name: pkg.name,
-        targetVersion: pkg.version,
-      })
-    }
-  }
-
-  return updates
+    return dependency && normalizeDependencyVersion(dependency) !== pkg.version
+      ? Result.succeed({
+          currentVersion: dependency,
+          name: pkg.name,
+          targetVersion: pkg.version,
+        })
+      : Result.failVoid
+  })
 }
 
 export default Command.make("update").pipe(
@@ -72,15 +73,12 @@ export default Command.make("update").pipe(
 
       const assessments = yield* collectAssessments()
 
-      const migrationChecks: Array<{
-        migration: Migration
-        result: MigrationCheckResult
-      }> = []
-
-      for (const migration of migrations.filter((candidate) => candidate.tags.includes("update"))) {
-        const result = yield* migration.check(migrationContext)
-        migrationChecks.push({ migration, result })
-      }
+      const migrationChecks = yield* pipe(
+        migrations.filter((candidate) => candidate.tags.includes("update")),
+        Effect.forEach((migration) =>
+          migration.check(migrationContext).pipe(Effect.map((result) => ({ migration, result })))
+        )
+      )
 
       // Assessments and migration checks derive warnings from the same detected state, so a Set
       // collapses the overlap.
@@ -116,30 +114,33 @@ export default Command.make("update").pipe(
 
       const packageJson = yield* readPackageJson(cwd)
       const postMigrationAssessments = yield* collectAssessments()
-      const doctorFollowUpActions = postMigrationAssessments
-        .flatMap(({ assessment }) => assessment.actions)
-        .filter(
-          (action) =>
-            action.type === "create_config" ||
-            action.type === "update_config" ||
-            action.type === "manual_fix"
-        )
-      const packageUpdates = postMigrationAssessments
-        .flatMap(({ assessment }) => assessment.actions)
-        .filter((action) => action.type === "install_package" || action.type === "update_package")
-        .map((action) =>
-          action.type === "install_package"
-            ? {
-                currentVersion: "not installed",
-                name: action.package,
-                targetVersion: action.targetVersion,
-              }
-            : {
-                currentVersion: action.currentVersion,
-                name: action.package,
-                targetVersion: action.targetVersion,
-              }
-        )
+      const postMigrationActions = postMigrationAssessments.flatMap(
+        ({ assessment }) => assessment.actions
+      )
+      const doctorFollowUpActions = postMigrationActions.filter(
+        (action) =>
+          action.type === "create_config" ||
+          action.type === "update_config" ||
+          action.type === "manual_fix"
+      )
+      const packageUpdates = Array.filterMap(postMigrationActions, (action) => {
+        switch (action.type) {
+          case "install_package":
+            return Result.succeed({
+              currentVersion: "not installed",
+              name: action.package,
+              targetVersion: action.targetVersion,
+            })
+          case "update_package":
+            return Result.succeed({
+              currentVersion: action.currentVersion,
+              name: action.package,
+              targetVersion: action.targetVersion,
+            })
+          default:
+            return Result.failVoid
+        }
+      })
       const coveredPackages = new Set(packageUpdates.map((update) => update.name))
       const updates = [
         ...packageUpdates,

--- a/src/lib/workspace/agents.ts
+++ b/src/lib/workspace/agents.ts
@@ -1,6 +1,9 @@
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
+import * as String from "effect/String"
 import { runScriptCommand, type PackageManagerName } from "nypm"
 import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
 import { MANAGED_SCRIPT_COMMANDS, type Script } from "#lib/workspace/package-json.ts"
@@ -79,13 +82,18 @@ export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOpt
           .readFileString(agentsPath)
           .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: agentsPath })))
       : ""
-    const start = existing.indexOf(ADAMANTITE_AGENTS_START_MARKER)
-    const endMarkerIndex = existing.indexOf(ADAMANTITE_AGENTS_END_MARKER)
+    const startIndex = pipe(existing, String.indexOf(ADAMANTITE_AGENTS_START_MARKER))
+    const endIndex = pipe(existing, String.indexOf(ADAMANTITE_AGENTS_END_MARKER))
+    const markerRange = pipe(
+      Option.all({ end: endIndex, start: startIndex }),
+      Option.filter(({ end, start }) => start < end)
+    )
     const section = getAgentsSection(options)
 
-    if (start !== -1 && endMarkerIndex !== -1 && start < endMarkerIndex) {
-      const end = endMarkerIndex + ADAMANTITE_AGENTS_END_MARKER.length
-      const nextContent = `${existing.slice(0, start)}${section.trimEnd()}${existing.slice(end)}`
+    if (Option.isSome(markerRange)) {
+      const { end, start } = markerRange.value
+      const sectionEnd = end + ADAMANTITE_AGENTS_END_MARKER.length
+      const nextContent = `${existing.slice(0, start)}${section.trimEnd()}${existing.slice(sectionEnd)}`
 
       yield* fs
         .writeFileString(agentsPath, nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`)
@@ -94,7 +102,7 @@ export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOpt
       return "updated" as const
     }
 
-    if (start !== -1 || endMarkerIndex !== -1) {
+    if (Option.isSome(startIndex) || Option.isSome(endIndex)) {
       return "malformed" as const
     }
 

--- a/src/lib/workspace/package-json.ts
+++ b/src/lib/workspace/package-json.ts
@@ -1,9 +1,12 @@
 import process from "node:process"
 import type { PackageManagerName } from "nypm"
 import type { PackageJson } from "type-fest"
+import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
+import { pipe } from "effect/Function"
 import * as Path from "effect/Path"
+import * as Record from "effect/Record"
 import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
 import { parseJson } from "#lib/shared/json.ts"
 
@@ -69,15 +72,9 @@ export const MANAGED_SCRIPT_COMMANDS = {
 
 export function getManagedScripts(packageJson: PackageJson): Script[] {
   const scripts = packageJson.scripts ?? {}
-  const managedScripts: Script[] = []
 
-  for (const [name, command] of Object.entries(MANAGED_SCRIPT_COMMANDS) as Array<
-    [Script, string]
-  >) {
-    if (scripts[name] === command) {
-      managedScripts.push(name)
-    }
-  }
-
-  return managedScripts
+  return pipe(
+    Record.keys(MANAGED_SCRIPT_COMMANDS),
+    Array.filter((name) => scripts[name] === MANAGED_SCRIPT_COMMANDS[name])
+  )
 }

--- a/src/lib/workspace/tooling/config.ts
+++ b/src/lib/workspace/tooling/config.ts
@@ -1,6 +1,9 @@
 import type { PackageJson } from "type-fest"
+import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import {
   defineIntegration,
@@ -60,15 +63,20 @@ function getConfigFormat(file: string): ToolingConfigFormat {
   return "ts"
 }
 
+function findLegacyConfigByFormat(files: ToolingConfigFiles, format: ToolingConfigFormat) {
+  return Array.findFirst(files.legacyConfigs, (file) => getConfigFormat(file) === format)
+}
+
 function getLegacyConfigDisplayName(files: ToolingConfigFiles) {
-  const jsonFile = files.legacyConfigs.find((file) => getConfigFormat(file) === "json")
-  const jsoncFile = files.legacyConfigs.find((file) => getConfigFormat(file) === "jsonc")
+  const jsonFile = findLegacyConfigByFormat(files, "json")
+  const jsoncFile = findLegacyConfigByFormat(files, "jsonc")
 
-  if (jsonFile && jsoncFile) {
-    return `${jsonFile}(c)`
-  }
-
-  return jsoncFile ?? jsonFile ?? ""
+  return pipe(
+    Option.zipWith(jsonFile, jsoncFile, (json) => `${json}(c)`),
+    Option.orElse(() => jsoncFile),
+    Option.orElse(() => jsonFile),
+    Option.getOrElse(() => "")
+  )
 }
 
 function getToolingConfigWarnings(
@@ -87,16 +95,15 @@ function getToolingConfigWarnings(
     ]
   }
 
-  const jsonFile = files.legacyConfigs.find((file) => getConfigFormat(file) === "json")
-  const jsoncFile = files.legacyConfigs.find((file) => getConfigFormat(file) === "jsonc")
-
-  if (!jsonFile || !jsoncFile) {
-    return []
-  }
-
-  return [
-    `Found both \`${jsonFile}\` and \`${jsoncFile}\`. Multiple legacy ${toolName} configs exist; Adamantite will treat \`${jsoncFile}\` as the source of truth when migration is needed.`,
-  ]
+  return pipe(
+    Option.zipWith(
+      findLegacyConfigByFormat(files, "json"),
+      findLegacyConfigByFormat(files, "jsonc"),
+      (jsonFile, jsoncFile) =>
+        `Found both \`${jsonFile}\` and \`${jsoncFile}\`. Multiple legacy ${toolName} configs exist; Adamantite will treat \`${jsoncFile}\` as the source of truth when migration is needed.`
+    ),
+    Option.toArray
+  )
 }
 
 /**
@@ -121,11 +128,12 @@ export const detectToolingConfig = Effect.fn("detectToolingConfig")(function* (
   })
   const present = candidates.filter((_, index) => existence[index])
 
-  const active =
-    present.find((candidate) => candidate.format === "ts") ??
-    present.find((candidate) => candidate.format === "jsonc") ??
-    present.find((candidate) => candidate.format === "json") ??
-    null
+  const active = pipe(
+    Array.findFirst(present, (candidate) => candidate.format === "ts"),
+    Option.orElse(() => Array.findFirst(present, (candidate) => candidate.format === "jsonc")),
+    Option.orElse(() => Array.findFirst(present, (candidate) => candidate.format === "json")),
+    Option.getOrNull
+  )
   const legacy = present.filter((candidate) => candidate !== active && candidate.format !== "ts")
 
   return {

--- a/src/lib/workspace/tooling/oxlint.ts
+++ b/src/lib/workspace/tooling/oxlint.ts
@@ -1,3 +1,5 @@
+import * as Array from "effect/Array"
+import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Predicate from "effect/Predicate"
 import { print as printAst } from "esrap"
@@ -118,57 +120,45 @@ function print(program: Program) {
 
 function getStaticPropertyName(key: PropertyKey) {
   if (key.type === "Identifier") {
-    return key.name
+    return pipe(key.name, Option.some)
   }
 
-  if (key.type === "Literal" && typeof key.value === "string") {
-    return key.value
+  if (key.type === "Literal" && Predicate.isString(key.value)) {
+    return pipe(key.value, Option.some)
   }
 
-  return null
+  return Option.none<string>()
+}
+
+function getConfigObjectExpression(declaration: ExportDefaultDeclaration["declaration"]) {
+  if (declaration.type === "ObjectExpression") {
+    return pipe(declaration, Option.some)
+  }
+
+  if (
+    declaration.type !== "CallExpression" ||
+    declaration.callee.type !== "Identifier" ||
+    declaration.callee.name !== "defineConfig"
+  ) {
+    return Option.none<ObjectExpression>()
+  }
+
+  return pipe(
+    declaration.arguments.length === 1 ? Array.head(declaration.arguments) : Option.none(),
+    Option.filter((argument): argument is ObjectExpression => argument.type === "ObjectExpression")
+  )
 }
 
 function getExportedConfigObject(ast: Program) {
-  const exportDefaultDeclarations = ast.body.filter(
-    (statement): statement is ExportDefaultDeclaration =>
-      statement.type === "ExportDefaultDeclaration"
+  return pipe(
+    ast.body,
+    Array.filter(
+      (statement): statement is ExportDefaultDeclaration =>
+        statement.type === "ExportDefaultDeclaration"
+    ),
+    (declarations) => (declarations.length === 1 ? Array.head(declarations) : Option.none()),
+    Option.flatMap((exported) => getConfigObjectExpression(exported.declaration))
   )
-
-  if (exportDefaultDeclarations.length !== 1) {
-    return Option.none()
-  }
-
-  const [exportDefaultDeclaration] = exportDefaultDeclarations
-
-  if (!exportDefaultDeclaration) {
-    return Option.none()
-  }
-
-  const declaration = exportDefaultDeclaration.declaration
-
-  if (declaration.type === "ObjectExpression") {
-    return Option.fromNullishOr(declaration)
-  }
-
-  if (declaration.type !== "CallExpression") {
-    return Option.none()
-  }
-
-  if (declaration.callee.type !== "Identifier" || declaration.callee.name !== "defineConfig") {
-    return Option.none()
-  }
-
-  if (declaration.arguments.length !== 1) {
-    return Option.none()
-  }
-
-  const [firstArgument] = declaration.arguments
-
-  if (firstArgument?.type === "ObjectExpression") {
-    return Option.fromNullishOr(firstArgument)
-  }
-
-  return Option.none()
 }
 
 function getNamedObjectProperty(
@@ -186,15 +176,17 @@ function getNamedObjectProperty(
       return { status: "manual" }
     }
 
+    const nameMatches = Option.contains(getStaticPropertyName(property.key), propertyName)
+
     if (property.method || property.kind !== "init") {
-      if (getStaticPropertyName(property.key) === propertyName) {
+      if (nameMatches) {
         return { status: "manual" }
       }
 
       continue
     }
 
-    if (getStaticPropertyName(property.key) !== propertyName) {
+    if (!nameMatches) {
       continue
     }
 


### PR DESCRIPTION
## Summary

Refactor five modules to use pipe-based `Array`, `Option`, `Record`, and `String` combinators from Effect. This matches the style of `src/lib/shared/errors.ts` (#363). The refactor does not change behavior.

## Changes

- `src/lib/workspace/agents.ts`: Use `String.indexOf` (`Option<number>`) for marker detection. Replace `-1` sentinels with `Option.all` and `Option.filter`.
- `src/lib/workspace/package-json.ts`: Rewrite `getManagedScripts` as `Record.keys` + `Array.filter`. Remove the `as Array<[Script, string]>` cast.
- `src/commands/update.ts`: Rewrite `getFallbackPackageUpdates` with `Array.filterMap`. Flatten post-migration actions in one pass. Replace the mutable `migrationChecks` loop with `Effect.forEach`.
- `src/lib/workspace/tooling/oxlint.ts`: Make `getStaticPropertyName` return `Option<string>`. Rewrite `getExportedConfigObject` as an `Option` pipeline with a `getConfigObjectExpression` helper.
- `src/lib/workspace/tooling/config.ts`: Select the active config with `Array.findFirst` + `Option.orElse` chains. Merge the legacy-config lookups into a shared `findLegacyConfigByFormat` helper with `Option.zipWith`.
- `docs/adr/0001-keep-no-array-callback-reference.md`: New ADR. It records the decision from the review discussion to keep `unicorn/no-array-callback-reference` in the core lint preset, and documents the compliant patterns for Effect code.

## Notes

- `Array.partition` is not applicable in `update.ts` because `run_migration` actions belong to no bucket of the two-way split.
- The v4 `Record.filter` widens literal keys (`NonLiteralKey<K>`), so `getManagedScripts` uses `Record.keys` to keep the `Script[]` type.
- The `unicorn/no-array-callback-reference` rule matches `Option.some(reference)` and `Effect.forEach(data, fn)`. The code uses `pipe(x, Option.some)` and the curried data-last `Effect.forEach` form to satisfy the rule. See ADR 0001 for the decision to keep the rule.

## Test plan

- `bun run check` passes.
- `bun run format` reports no changes.
- `bun run analyze` reports no issues.
- `bun run test`: 302 tests pass.

No changeset: internal maintenance and contributor documentation, with no CLI behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)