### PR TITLE
Skip catch-all root tsconfig in monorepos during legacy typecheck migration

### DIFF
--- a/.changeset/lucky-otters-attend.md
+++ b/.changeset/lucky-otters-attend.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Skip root `tsconfig.json` creation and updates in the `legacy-typecheck-script` migration when a monorepo is detected. The migration, reachable through `adamantite update` and `adamantite doctor --fix`, previously wrote back the catch-all root config that `init` stopped writing in monorepos. It now prints the same guidance as `init` — add `"extends": "adamantite/typescript"` to each package's `tsconfig.json` or to a shared base config — and its validation no longer reports a failure for the deliberately absent file.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,6 +5,7 @@ import process from "node:process"
 import type { PackageManagerName } from "nypm"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
 import * as Predicate from "effect/Predicate"
 import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
@@ -30,7 +31,7 @@ import {
   type Script,
   type SupportedPackageManager,
 } from "#lib/workspace/package-json.ts"
-import tsconfig from "#lib/workspace/tsconfig.ts"
+import tsconfig, { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 import { Prompter } from "#terminal/prompter.ts"
 import { printTitle } from "#terminal/title.ts"
 
@@ -142,11 +143,9 @@ const setupTypescript = (cwd: string, isMonorepo: boolean) =>
     const prompter = yield* Prompter
 
     if (isMonorepo) {
-      yield* prompter.log.info(
-        "Skipping `tsconfig.json` setup: a root config in a monorepo makes TypeScript treat all packages as one project."
-      )
-      yield* prompter.log.info(
-        'To use the TypeScript preset, add `"extends": "adamantite/typescript"` to each package\'s `tsconfig.json` or to a shared base config.'
+      yield* pipe(
+        MONOREPO_GUIDANCE,
+        Effect.forEach((line) => prompter.log.info(line))
       )
       return
     }

--- a/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
+++ b/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
@@ -13,13 +13,13 @@ import {
 import migrationLegacyOxlintJson from "#lib/migrations/legacy-oxlint-json.ts"
 import migrationLegacyTypecheckScript from "#lib/migrations/legacy-typecheck-script.ts"
 import { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
+import { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 
 function runTestEffect<A, E, R>(
   effect: Effect.Effect<A, E, R>,
-  options?: Parameters<typeof createDependencyInstallerTestContext>[0]
+  prompterContext = createPrompterTestContext()
 ) {
-  const prompterContext = createPrompterTestContext()
-  const dependencyInstallerContext = createDependencyInstallerTestContext(options)
+  const dependencyInstallerContext = createDependencyInstallerTestContext()
   const provided = effect.pipe(
     Effect.provide(
       Layer.mergeAll(
@@ -200,6 +200,69 @@ describe("legacyTypecheckScript", () => {
     expect(oxlintConfig).toBe(migratedOxlintConfig)
     expect(tsconfig.compilerOptions).toEqual({ strict: true })
     expect(tsconfig.extends).toBe("adamantite/typescript")
+  })
+
+  test("migrate prints guidance instead of writing a root tsconfig in a monorepo", async () => {
+    await Bun.write(
+      "package.json",
+      JSON.stringify(
+        {
+          name: "test-project",
+          scripts: {
+            typecheck: "adamantite typecheck",
+          },
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+        },
+        null,
+        2
+      )
+    )
+
+    const prompterContext = createPrompterTestContext()
+    await runTestEffect(migrationLegacyTypecheckScript.migrate({ cwd: tempDir }), prompterContext)
+
+    expect(await Bun.file("tsconfig.json").exists()).toBe(false)
+
+    for (const message of MONOREPO_GUIDANCE) {
+      expect(prompterContext.logs).toContainEqual({ level: "info", message })
+    }
+
+    await runTestEffect(migrationLegacyTypecheckScript.validate({ cwd: tempDir }))
+  })
+
+  test("migrate leaves an existing root tsconfig unchanged in a monorepo", async () => {
+    await Bun.write(
+      "package.json",
+      JSON.stringify(
+        {
+          name: "test-project",
+          scripts: {
+            typecheck: "adamantite typecheck",
+          },
+          version: "1.0.0",
+        },
+        null,
+        2
+      )
+    )
+    await Bun.write("pnpm-workspace.yaml", "packages:\n  - packages/*\n")
+    const existingTsconfig = JSON.stringify(
+      {
+        extends: "./tooling/tsconfig.base.json",
+        files: [],
+        references: [{ path: "packages/app" }],
+      },
+      null,
+      2
+    )
+    await Bun.write("tsconfig.json", existingTsconfig)
+
+    await runTestEffect(migrationLegacyTypecheckScript.migrate({ cwd: tempDir }))
+
+    expect(await Bun.file("tsconfig.json").text()).toBe(existingTsconfig)
+
+    await runTestEffect(migrationLegacyTypecheckScript.validate({ cwd: tempDir }))
   })
 
   test("migrate updates the GitHub Actions workflow when it exists", async () => {

--- a/src/lib/migrations/legacy-typecheck-script.ts
+++ b/src/lib/migrations/legacy-typecheck-script.ts
@@ -7,6 +7,7 @@ import { defineMigration } from "#lib/migrations/base.ts"
 import { MigrationValidationFailed } from "#lib/shared/errors.ts"
 import { hasCICompatibleScripts } from "#lib/workspace/ci-scripts.ts"
 import { DependencyInstaller } from "#lib/workspace/dependency-installer.ts"
+import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
 import {
   checkIsSupportedPackageManager,
   getManagedScripts,
@@ -14,7 +15,6 @@ import {
   writePackageJson,
   MANAGED_SCRIPT_COMMANDS,
 } from "#lib/workspace/package-json.ts"
-import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
 import tsconfig, { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 import { Prompter } from "#terminal/prompter.ts"
 

--- a/src/lib/migrations/legacy-typecheck-script.ts
+++ b/src/lib/migrations/legacy-typecheck-script.ts
@@ -1,5 +1,6 @@
 import type { PackageJson } from "type-fest"
 import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
 import github from "#lib/integrations/ci/github.ts"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
@@ -13,7 +14,8 @@ import {
   writePackageJson,
   MANAGED_SCRIPT_COMMANDS,
 } from "#lib/workspace/package-json.ts"
-import tsconfig from "#lib/workspace/tsconfig.ts"
+import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
+import tsconfig, { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 import { Prompter } from "#terminal/prompter.ts"
 
 const LEGACY_TYPECHECK_SCRIPT_COMMAND = "adamantite typecheck"
@@ -97,8 +99,17 @@ export default defineMigration({
           yield* oxlint.update(context.cwd)
         }
 
-        const hasTypescriptConfig = yield* tsconfig.detect(context.cwd)
-        yield* hasTypescriptConfig ? tsconfig.update(context.cwd) : tsconfig.create(context.cwd)
+        const isMonorepo = yield* checkIsMonorepo(context.cwd)
+
+        if (isMonorepo) {
+          yield* pipe(
+            MONOREPO_GUIDANCE,
+            Effect.forEach((line) => prompter.log.info(line))
+          )
+        } else {
+          const hasTypescriptConfig = yield* tsconfig.detect(context.cwd)
+          yield* hasTypescriptConfig ? tsconfig.update(context.cwd) : tsconfig.create(context.cwd)
+        }
 
         const workflowExists = yield* github.detect(context.cwd)
         const managedScripts = getManagedScripts(migratedPackageJson.packageJson)
@@ -170,6 +181,12 @@ export default defineMigration({
           migrationId: "legacy-typecheck-script",
           reason: `\`${oxlint.config}\` is not the active oxlint config.`,
         })
+      }
+
+      const isMonorepo = yield* checkIsMonorepo(context.cwd)
+
+      if (isMonorepo) {
+        return
       }
 
       const hasTypescriptConfig = yield* tsconfig.detect(context.cwd)

--- a/src/lib/workspace/tsconfig.ts
+++ b/src/lib/workspace/tsconfig.ts
@@ -11,6 +11,11 @@ const files = [{ path: "tsconfig.json", type: "config" }] as const
 const PRESET_EXTENDS = "adamantite/typescript"
 const CONFIG = { extends: PRESET_EXTENDS }
 
+export const MONOREPO_GUIDANCE = [
+  "Skipping `tsconfig.json` setup: a root config in a monorepo makes TypeScript treat all packages as one project.",
+  `To use the TypeScript preset, add \`"extends": "${PRESET_EXTENDS}"\` to each package's \`tsconfig.json\` or to a shared base config.`,
+] as const
+
 // Later entries in an `extends` array override earlier ones, so the preset is
 // appended last when Adamantite adds it. An array that already contains the
 // preset is kept in the user's order, even when the preset is not last.


### PR DESCRIPTION
Fixes #362. Follow-up to #361.

The `legacy-typecheck-script` migration (reachable via `adamantite update` and `adamantite doctor --fix`) called `tsconfig.update`/`tsconfig.create` unconditionally, so monorepo users still carrying the legacy `typecheck` script got the catch-all root `tsconfig.json` that #361 stopped `init` from writing.

## Changes

- **`src/lib/migrations/legacy-typecheck-script.ts`** — `migrate` checks `checkIsMonorepo` before touching `tsconfig.json`: in a monorepo it prints guidance instead of creating or updating the file. `validate` returns early in a monorepo so the deliberately absent file no longer reports `MigrationValidationFailed` (the script and oxlint checks still run).
- **`src/lib/workspace/tsconfig.ts`** — the two guidance lines are extracted into an exported `MONOREPO_GUIDANCE` constant, built from the existing `PRESET_EXTENDS`.
- **`src/commands/init.ts`** — `setupTypescript` logs the shared constant instead of its own duplicated strings. The `init` tests pinning the literal text still pass, confirming the extracted constant is byte-identical.
- **Tests** — new migration tests cover a `workspaces`-based monorepo (no `tsconfig.json` written, guidance logged, `validate` passes) and a `pnpm-workspace.yaml` monorepo with an existing root `tsconfig.json` (left byte-for-byte unchanged, `validate` passes).

In a monorepo the migration also skips *updating* an existing root `tsconfig.json`, matching `init`'s behavior from #361 — appending the preset's catch-all `include` to a project-references root config would cause the same all-packages-as-one-project problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)