### PR TITLE
Preserve existing package scripts during init unless overwriting is confirmed

### DIFF
--- a/.changeset/brave-scripts-remain.md
+++ b/.changeset/brave-scripts-remain.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Stop `init` from silently overwriting existing package scripts. Scripts whose commands differ from Adamantite's managed commands are now kept and reported: the interactive initializer asks once before overwriting, and non-interactive runs preserve them unless the new `--overwrite-scripts` flag is passed. Preserved scripts are omitted from AGENTS.md guidance.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Presets and TypeScript require the `check` or `fix` script. Editor extension ins
 requires an editor. Monorepo scripts require a detected monorepo. GitHub Actions requires a
 compatible script and a supported package manager. Omitted boolean flags are disabled.
 
+Existing package scripts whose commands differ from Adamantite's are kept and reported
+instead of being replaced. The interactive initializer asks before overwriting them; in
+non-interactive mode, pass `--overwrite-scripts` to replace them. To keep custom flags,
+forward them to the Adamantite command after `--`, e.g.
+`adamantite monorepo -- --ignore-dependency tailwindcss`.
+
 In a detected monorepo, TypeScript setup does not write a root `tsconfig.json`, because a
 catch-all root config makes TypeScript treat all packages as one project. Adamantite
 prints guidance instead: add `"extends": "adamantite/typescript"` to each package's

--- a/skills/adamantite/SKILL.md
+++ b/skills/adamantite/SKILL.md
@@ -29,12 +29,17 @@ Repeat `--script`, `--preset`, and `--editor` for multiple values. Available val
 
 - Scripts: `check`, `fix`, `format`, `analyze`, `check:monorepo`, `fix:monorepo`
 - Presets: `react`, `nextjs`, `vue`, `jest`, `vitest`, `node`; editors: `vscode`, `zed`
-- Optional flags: `--typescript`, `--install-extensions`, `--github-actions`, `--agents`
+- Optional flags: `--typescript`, `--install-extensions`, `--github-actions`, `--agents`,
+  `--overwrite-scripts`
 
 Only select options supported by the project. Presets and TypeScript require `check` or
 `fix`; extension installation requires an editor; monorepo scripts require a detected
 monorepo; `--github-actions` requires a CI-compatible script and a supported package
 manager (bun, deno, npm, pnpm, or yarn). Omitted boolean flags are disabled.
+
+Existing package scripts whose commands differ from Adamantite's are kept and reported,
+not replaced; pass `--overwrite-scripts` to replace them. Custom flags can be forwarded
+to the Adamantite command after `--`, e.g. `adamantite monorepo -- --ignore-dependency tailwindcss`.
 
 ## Daily workflow
 

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -669,6 +669,11 @@ describe("init", () => {
         name: "setup flags without non-interactive mode",
         reason: "Setup flags require `--non-interactive`.",
       },
+      {
+        args: ["--overwrite-scripts"],
+        name: "script overwriting without non-interactive mode",
+        reason: "Setup flags require `--non-interactive`.",
+      },
     ])("reject $name before changing the project", async ({ args, reason }) => {
       const originalPackageJson = await readFile(join(tempDir, "package.json"), "utf8")
       const prompter = createPrompterTestContext()
@@ -723,6 +728,216 @@ describe("init", () => {
 
       expect(Exit.isFailure(exit)).toBe(true)
       expect(installer.calls).toEqual([])
+    })
+  })
+
+  describe("existing scripts", () => {
+    const conflictingMonorepoPackageJson = JSON.stringify(
+      {
+        name: "test-project",
+        scripts: {
+          "check:monorepo": "sherif --ignore-dependency tailwindcss",
+        },
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+      },
+      null,
+      2
+    )
+
+    test("preserve conflicting scripts and warn in non-interactive mode", async () => {
+      await writeFile(join(tempDir, "package.json"), conflictingMonorepoPackageJson)
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(
+        initCommand,
+        ["--non-interactive", "--script", "check:monorepo", "--script", "fix:monorepo"],
+        [prompter.layer, installer.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.confirmCalls).toEqual([])
+
+      const packageJson = await readJson<{ scripts: Record<string, string> }>(
+        join(tempDir, "package.json")
+      )
+      expect(packageJson.scripts).toEqual({
+        "check:monorepo": "sherif --ignore-dependency tailwindcss",
+        "fix:monorepo": "adamantite monorepo --fix",
+      })
+
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message:
+          "Kept existing `check:monorepo` script (`sherif --ignore-dependency tailwindcss`) instead of `adamantite monorepo`. Use `--overwrite-scripts` to replace it.",
+      })
+      expect(prompter.logs).toContainEqual({
+        level: "info",
+        message:
+          "Adamantite commands forward extra arguments after `--`, so custom flags can be kept, e.g. `adamantite monorepo -- --ignore-dependency tailwindcss`.",
+      })
+    })
+
+    test("replace conflicting scripts when --overwrite-scripts is passed", async () => {
+      await writeFile(join(tempDir, "package.json"), conflictingMonorepoPackageJson)
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(
+        initCommand,
+        [
+          "--non-interactive",
+          "--script",
+          "check:monorepo",
+          "--script",
+          "fix:monorepo",
+          "--overwrite-scripts",
+        ],
+        [prompter.layer, installer.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const packageJson = await readJson<{ scripts: Record<string, string> }>(
+        join(tempDir, "package.json")
+      )
+      expect(packageJson.scripts).toEqual({
+        "check:monorepo": "adamantite monorepo",
+        "fix:monorepo": "adamantite monorepo --fix",
+      })
+      expect(prompter.logs).not.toContainEqual(
+        expect.objectContaining({ message: expect.stringContaining("Kept existing") })
+      )
+    })
+
+    test("replace conflicting scripts when overwriting is confirmed interactively", async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test-project",
+            scripts: { check: "tsc && eslint ." },
+            version: "1.0.0",
+          },
+          null,
+          2
+        )
+      )
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [true, false, false, false],
+        multiselectResponses: [["check"], [], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message:
+          "`check` is currently `tsc && eslint .`; Adamantite would replace it with `adamantite check`.",
+      })
+      expect(prompter.confirmCalls[0]).toMatchObject({
+        message: "Overwrite this existing script with Adamantite's command?",
+      })
+
+      const packageJson = await readJson<{ scripts: Record<string, string> }>(
+        join(tempDir, "package.json")
+      )
+      expect(packageJson.scripts).toEqual({ check: "adamantite check" })
+    })
+
+    test("preserve conflicting scripts when overwriting is declined interactively", async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test-project",
+            scripts: { check: "tsc && eslint ." },
+            version: "1.0.0",
+          },
+          null,
+          2
+        )
+      )
+
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, false, false, false],
+        multiselectResponses: [["check"], [], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const packageJson = await readJson<{ scripts: Record<string, string> }>(
+        join(tempDir, "package.json")
+      )
+      expect(packageJson.scripts).toEqual({ check: "tsc && eslint ." })
+      expect(prompter.logs).toContainEqual({
+        level: "warning",
+        message:
+          "Kept existing `check` script (`tsc && eslint .`) instead of `adamantite check`. Use `--overwrite-scripts` to replace it.",
+      })
+    })
+
+    test("do not prompt or warn when existing scripts already match the managed commands", async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "test-project",
+            scripts: { check: "adamantite check" },
+            version: "1.0.0",
+          },
+          null,
+          2
+        )
+      )
+
+      // Only the typescript, CI, and agents confirms should fire; an overwrite
+      // confirm would fail the run with a missing confirm response.
+      const prompter = createPrompterTestContext({
+        confirmResponses: [false, false, false],
+        multiselectResponses: [["check"], [], []],
+      })
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(initCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(prompter.logs).not.toContainEqual(
+        expect.objectContaining({ message: expect.stringContaining("Kept existing") })
+      )
+
+      const packageJson = await readJson<{ scripts: Record<string, string> }>(
+        join(tempDir, "package.json")
+      )
+      expect(packageJson.scripts).toEqual({ check: "adamantite check" })
+    })
+
+    test("omit preserved scripts from AGENTS.md guidance", async () => {
+      await writeFile(join(tempDir, "package.json"), conflictingMonorepoPackageJson)
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(
+        initCommand,
+        ["--non-interactive", "--script", "check:monorepo", "--script", "format", "--agents"],
+        [prompter.layer, installer.layer]
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      const agents = await readFile(join(tempDir, "AGENTS.md"), "utf8")
+      expect(agents).toContain("Run `bun run format` after editing files")
+      expect(agents).not.toContain("check:monorepo")
     })
   })
 

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -882,7 +882,7 @@ describe("init", () => {
       expect(prompter.logs).toContainEqual({
         level: "warning",
         message:
-          "Kept existing `check` script (`tsc && eslint .`) instead of `adamantite check`. Use `--overwrite-scripts` to replace it.",
+          "Kept existing `check` script (`tsc && eslint .`) instead of `adamantite check`. Re-run `adamantite init` and confirm overwriting to replace it.",
       })
     })
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -24,10 +24,12 @@ import { DependencyInstaller } from "#lib/workspace/dependency-installer.ts"
 import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
 import {
   checkIsSupportedPackageManager,
+  getConflictingScripts,
   readPackageJson,
   writePackageJson,
   MANAGED_SCRIPT_COMMANDS,
   type Script,
+  type ScriptConflict,
   type SupportedPackageManager,
 } from "#lib/workspace/package-json.ts"
 import tsconfig from "#lib/workspace/tsconfig.ts"
@@ -114,16 +116,27 @@ function setupToolConfig<E, R>(
   })
 }
 
-const addScripts = (cwd: string, scripts: Script[]) =>
+const describeScriptConflict = (conflict: ScriptConflict) =>
+  `\`${conflict.script}\` is currently \`${conflict.command}\`; Adamantite would replace it with \`${MANAGED_SCRIPT_COMMANDS[conflict.script]}\`.`
+
+const addScripts = (cwd: string, scripts: Script[], overwriteScripts: boolean) =>
   Effect.gen(function* () {
     const prompter = yield* Prompter
     const packageJson = yield* readPackageJson(cwd)
+    const conflicts = overwriteScripts ? [] : getConflictingScripts(packageJson, scripts)
+    const conflictingNames = new Set(conflicts.map((conflict) => conflict.script))
+    const writtenScripts = scripts.filter((script) => !conflictingNames.has(script))
+
     yield* prompter.withSpinner(
       () =>
         Effect.gen(function* () {
+          if (writtenScripts.length === 0) {
+            return
+          }
+
           packageJson.scripts ??= {}
 
-          for (const script of scripts) {
+          for (const script of writtenScripts) {
             packageJson.scripts[script] = MANAGED_SCRIPT_COMMANDS[script]
           }
 
@@ -132,9 +145,28 @@ const addScripts = (cwd: string, scripts: Script[]) =>
       {
         failure: "Failed to add scripts to `package.json`.",
         start: "Adding scripts to your `package.json`...",
-        success: "Scripts added to your `package.json`",
+        success:
+          writtenScripts.length === 0
+            ? "Kept your existing `package.json` scripts."
+            : conflicts.length > 0
+              ? "Scripts added to your `package.json`; conflicting scripts were kept."
+              : "Scripts added to your `package.json`",
       }
     )
+
+    for (const conflict of conflicts) {
+      yield* prompter.log.warning(
+        `Kept existing \`${conflict.script}\` script (\`${conflict.command}\`) instead of \`${MANAGED_SCRIPT_COMMANDS[conflict.script]}\`. Use \`--overwrite-scripts\` to replace it.`
+      )
+    }
+
+    if (conflicts.length > 0) {
+      yield* prompter.log.info(
+        "Adamantite commands forward extra arguments after `--`, so custom flags can be kept, e.g. `adamantite monorepo -- --ignore-dependency tailwindcss`."
+      )
+    }
+
+    return writtenScripts
   })
 
 const setupTypescript = (cwd: string, isMonorepo: boolean) =>
@@ -354,6 +386,7 @@ interface InitOptions {
   readonly editors: InitEditor[]
   readonly githubActions: boolean
   readonly installExtensions: boolean
+  readonly overwriteScripts: boolean
   readonly presets: InitPreset[]
   readonly scripts: Script[]
   readonly typescript: boolean
@@ -364,6 +397,7 @@ interface InitOptionsInput {
   readonly editors: readonly InitEditor[]
   readonly githubActions: boolean
   readonly installExtensions: boolean
+  readonly overwriteScripts: boolean
   readonly presets: readonly InitPreset[]
   readonly scripts: readonly Script[]
   readonly typescript: boolean
@@ -384,6 +418,7 @@ const validateInitOptions = Effect.fn("validateInitOptions")(function* (
     editors: Array.dedupe(input.editors),
     githubActions: input.githubActions,
     installExtensions: input.installExtensions,
+    overwriteScripts: input.overwriteScripts,
     presets: Array.dedupe(input.presets),
     scripts: Array.dedupe(input.scripts),
     typescript: input.typescript,
@@ -481,7 +516,14 @@ const agents = Flag.boolean("agents").pipe(
   Flag.withDescription("Add Adamantite guidance to AGENTS.md")
 )
 
+const overwriteScripts = Flag.boolean("overwrite-scripts").pipe(
+  Flag.withDescription(
+    "Replace existing package scripts that conflict with Adamantite's managed commands"
+  )
+)
+
 const collectInteractiveInitOptions = Effect.fn("collectInteractiveInitOptions")(function* (
+  cwd: string,
   isMonorepo: boolean
 ) {
   const prompter = yield* Prompter
@@ -522,6 +564,24 @@ const collectInteractiveInitOptions = Effect.fn("collectInteractiveInitOptions")
       },
     ],
   })
+
+  const packageJson = yield* readPackageJson(cwd)
+  const conflicts = getConflictingScripts(packageJson, selectedScripts)
+  let shouldOverwriteScripts = false
+
+  if (conflicts.length > 0) {
+    for (const conflict of conflicts) {
+      yield* prompter.log.warning(describeScriptConflict(conflict))
+    }
+
+    shouldOverwriteScripts = yield* prompter.confirm({
+      initialValue: false,
+      message:
+        conflicts.length === 1
+          ? "Overwrite this existing script with Adamantite's command?"
+          : "Overwrite these existing scripts with Adamantite's commands?",
+    })
+  }
 
   const hasOxlint = selectedScripts.includes("check") || selectedScripts.includes("fix")
   let selectedPresets: InitOptions["presets"] = []
@@ -584,6 +644,7 @@ const collectInteractiveInitOptions = Effect.fn("collectInteractiveInitOptions")
     editors: selectedEditors,
     githubActions: shouldEnableGitHubActions,
     installExtensions: shouldInstallExtensions,
+    overwriteScripts: shouldOverwriteScripts,
     presets: selectedPresets,
     scripts: selectedScripts,
     typescript: shouldSetupTypescript,
@@ -596,6 +657,7 @@ export default Command.make("init", {
   githubActions,
   installExtensions,
   nonInteractive,
+  overwriteScripts,
   presets,
   scripts,
   typescript,
@@ -659,6 +721,7 @@ export default Command.make("init", {
             options.installExtensions,
             options.githubActions,
             options.agents,
+            options.overwriteScripts,
           ],
           Predicate.isTruthy
         )
@@ -670,7 +733,7 @@ export default Command.make("init", {
 
       const input = options.nonInteractive
         ? options
-        : yield* collectInteractiveInitOptions(isMonorepo)
+        : yield* collectInteractiveInitOptions(cwd, isMonorepo)
       const initOptions = yield* validateInitOptions(input, {
         isMonorepo,
         nonInteractive: options.nonInteractive,
@@ -726,10 +789,10 @@ export default Command.make("init", {
         yield* setupToolConfig(cwd, knip, knip.create(cwd))
       }
 
-      yield* addScripts(cwd, selectedScripts)
+      const writtenScripts = yield* addScripts(cwd, selectedScripts, initOptions.overwriteScripts)
 
       if (shouldAddAgentsGuidance) {
-        yield* setupAgentsGuidance(cwd, packageManager.name, selectedScripts)
+        yield* setupAgentsGuidance(cwd, packageManager.name, writtenScripts)
       }
 
       if (shouldSetupTypescript) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -119,11 +119,15 @@ function setupToolConfig<E, R>(
 const describeScriptConflict = (conflict: ScriptConflict) =>
   `\`${conflict.script}\` is currently \`${conflict.command}\`; Adamantite would replace it with \`${MANAGED_SCRIPT_COMMANDS[conflict.script]}\`.`
 
-const addScripts = (cwd: string, scripts: Script[], overwriteScripts: boolean) =>
+const addScripts = (
+  cwd: string,
+  scripts: Script[],
+  options: { readonly nonInteractive: boolean; readonly overwriteScripts: boolean }
+) =>
   Effect.gen(function* () {
     const prompter = yield* Prompter
     const packageJson = yield* readPackageJson(cwd)
-    const conflicts = overwriteScripts ? [] : getConflictingScripts(packageJson, scripts)
+    const conflicts = options.overwriteScripts ? [] : getConflictingScripts(packageJson, scripts)
     const conflictingNames = new Set(conflicts.map((conflict) => conflict.script))
     const writtenScripts = scripts.filter((script) => !conflictingNames.has(script))
 
@@ -146,17 +150,21 @@ const addScripts = (cwd: string, scripts: Script[], overwriteScripts: boolean) =
         failure: "Failed to add scripts to `package.json`.",
         start: "Adding scripts to your `package.json`...",
         success:
-          writtenScripts.length === 0
-            ? "Kept your existing `package.json` scripts."
-            : conflicts.length > 0
-              ? "Scripts added to your `package.json`; conflicting scripts were kept."
-              : "Scripts added to your `package.json`",
+          conflicts.length === 0
+            ? "Scripts added to your `package.json`"
+            : writtenScripts.length === 0
+              ? "Kept your existing `package.json` scripts."
+              : "Scripts added to your `package.json`; conflicting scripts were kept.",
       }
     )
 
+    const replaceHint = options.nonInteractive
+      ? "Use `--overwrite-scripts` to replace it."
+      : "Re-run `adamantite init` and confirm overwriting to replace it."
+
     for (const conflict of conflicts) {
       yield* prompter.log.warning(
-        `Kept existing \`${conflict.script}\` script (\`${conflict.command}\`) instead of \`${MANAGED_SCRIPT_COMMANDS[conflict.script]}\`. Use \`--overwrite-scripts\` to replace it.`
+        `Kept existing \`${conflict.script}\` script (\`${conflict.command}\`) instead of \`${MANAGED_SCRIPT_COMMANDS[conflict.script]}\`. ${replaceHint}`
       )
     }
 
@@ -789,7 +797,10 @@ export default Command.make("init", {
         yield* setupToolConfig(cwd, knip, knip.create(cwd))
       }
 
-      const writtenScripts = yield* addScripts(cwd, selectedScripts, initOptions.overwriteScripts)
+      const writtenScripts = yield* addScripts(cwd, selectedScripts, {
+        nonInteractive: options.nonInteractive,
+        overwriteScripts: initOptions.overwriteScripts,
+      })
 
       if (shouldAddAgentsGuidance) {
         yield* setupAgentsGuidance(cwd, packageManager.name, writtenScripts)

--- a/src/lib/workspace/__tests__/package-json.test.ts
+++ b/src/lib/workspace/__tests__/package-json.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { getConflictingScripts } from "#lib/workspace/package-json.ts"
+
+describe("getConflictingScripts", () => {
+  test("returns scripts whose existing command differs from the managed command", () => {
+    const conflicts = getConflictingScripts(
+      {
+        scripts: {
+          "check:monorepo": "sherif --ignore-dependency tailwindcss",
+          "fix:monorepo": "sherif --fix --ignore-dependency tailwindcss",
+        },
+      },
+      ["check:monorepo", "fix:monorepo"]
+    )
+
+    expect(conflicts).toEqual([
+      { command: "sherif --ignore-dependency tailwindcss", script: "check:monorepo" },
+      { command: "sherif --fix --ignore-dependency tailwindcss", script: "fix:monorepo" },
+    ])
+  })
+
+  test("does not report scripts that already use the managed command", () => {
+    const conflicts = getConflictingScripts(
+      {
+        scripts: {
+          check: "adamantite check",
+          format: "adamantite format",
+        },
+      },
+      ["check", "format"]
+    )
+
+    expect(conflicts).toEqual([])
+  })
+
+  test("does not report missing or empty scripts", () => {
+    const conflicts = getConflictingScripts(
+      {
+        scripts: {
+          check: "",
+        },
+      },
+      ["check", "format"]
+    )
+
+    expect(conflicts).toEqual([])
+  })
+
+  test("handles a package.json without a scripts field", () => {
+    expect(getConflictingScripts({}, ["check"])).toEqual([])
+  })
+
+  test("only inspects the requested scripts", () => {
+    const conflicts = getConflictingScripts(
+      {
+        scripts: {
+          check: "tsc && eslint .",
+          format: "prettier --write .",
+        },
+      },
+      ["format"]
+    )
+
+    expect(conflicts).toEqual([{ command: "prettier --write .", script: "format" }])
+  })
+})

--- a/src/lib/workspace/package-json.ts
+++ b/src/lib/workspace/package-json.ts
@@ -7,6 +7,7 @@ import * as FileSystem from "effect/FileSystem"
 import { pipe } from "effect/Function"
 import * as Path from "effect/Path"
 import * as Record from "effect/Record"
+import * as Result from "effect/Result"
 import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
 import { parseJson } from "#lib/shared/json.ts"
 
@@ -77,4 +78,29 @@ export function getManagedScripts(packageJson: PackageJson): Script[] {
     Record.keys(MANAGED_SCRIPT_COMMANDS),
     Array.filter((name) => scripts[name] === MANAGED_SCRIPT_COMMANDS[name])
   )
+}
+
+export interface ScriptConflict {
+  readonly command: string
+  readonly script: Script
+}
+
+/**
+ * Finds requested scripts whose existing `package.json` command differs from the managed Adamantite
+ * command. Missing, empty, and already-managed scripts are not conflicts, so re-running `adamantite
+ * init` stays idempotent.
+ */
+export function getConflictingScripts(
+  packageJson: PackageJson,
+  scripts: readonly Script[]
+): ScriptConflict[] {
+  const existing = packageJson.scripts ?? {}
+
+  return Array.filterMap(scripts, (script) => {
+    const command = existing[script]
+
+    return command !== undefined && command !== "" && command !== MANAGED_SCRIPT_COMMANDS[script]
+      ? Result.succeed({ command, script })
+      : Result.failVoid
+  })
 }


### PR DESCRIPTION
Fixes #358

## Problem

`adamantite init` wrote every selected script into `package.json` unconditionally, silently discarding user-specific commands such as `check:monorepo: "sherif --ignore-dependency tailwindcss"` — which could turn a passing check into a failing one.

## Changes

- **New `getConflictingScripts` helper** in `src/lib/workspace/package-json.ts`: a requested script conflicts when its existing command is non-empty and differs from the managed Adamantite command. Exact matches are not conflicts, so re-running `init` stays idempotent.
- **Interactive mode** shows each conflict (current vs. managed command) right after script selection and asks a single confirm, defaulting to keep.
- **Non-interactive mode** never overwrites by default; each preserved script is reported with a warning, plus a hint that Adamantite commands forward extra arguments after `--` (e.g. `adamantite monorepo -- --ignore-dependency tailwindcss`). The new `--overwrite-scripts` flag restores the previous replace behavior and, like other setup flags, requires `--non-interactive`.
- **AGENTS.md guidance** only documents scripts that were actually written, since it claims each script maps to a specific Adamantite command. CI generation still receives all selected scripts, as the script names remain runnable either way.

## Testing

- New `describe("existing scripts")` block in `init.test.ts`: non-interactive preserve + warnings, `--overwrite-scripts` replace, interactive confirm accepted/declined, idempotent re-run with matching scripts, and AGENTS.md omission of preserved scripts.
- New unit tests for `getConflictingScripts`.
- Full local matrix passes: `bun run check`, `bun run format --check`, `bun run test` (343 pass), `bun run analyze`, `bun run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)