### PR TITLE
Restrict terminal output to commands: migrations report results, not print

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -8,4 +8,23 @@ export default defineConfig({
     typeAware: true,
     typeCheck: true,
   },
+  overrides: [
+    {
+      files: ["src/lib/**/*.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: [
+              {
+                group: ["#terminal/*"],
+                message:
+                  "Terminal interaction belongs to commands/ and index.ts; lib code returns data for commands to render.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 })

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -587,9 +587,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, ".oxfmtrc.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "oxfmt.config.ts")).exists()).toBe(true)
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Oxfmt config migrated to `oxfmt.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `.oxfmtrc.json` to `oxfmt.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -672,9 +672,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${oxfmt.name}@${oxfmt.version}\`.`,
     })
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Oxfmt config migrated to `oxfmt.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `.oxfmtrc.json` to `oxfmt.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -790,9 +790,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, "knip.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "knip.config.ts")).exists()).toBe(true)
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Knip config migrated to `knip.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `knip.json` to `knip.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -838,9 +838,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${knip.name}@${knip.version}\`.`,
     })
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Knip config migrated to `knip.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `knip.json` to `knip.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -959,9 +959,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, ".oxlintrc.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "oxlint.config.ts")).exists()).toBe(true)
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Oxlint config migrated to `oxlint.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `.oxlintrc.json` to `oxlint.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -1008,9 +1008,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${oxlint.name}@${oxlint.version}\`.`,
     })
-    expect(prompter.spinnerEntries).toContainEqual({
-      message: "Oxlint config migrated to `oxlint.config.ts` successfully.",
-      type: "stop",
+    expect(prompter.logs).toContainEqual({
+      level: "success",
+      message: "Fixed: Migrate legacy `.oxlintrc.json` to `oxlint.config.ts`.",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })

--- a/src/commands/__tests__/doctor.test.ts
+++ b/src/commands/__tests__/doctor.test.ts
@@ -587,9 +587,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, ".oxfmtrc.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "oxfmt.config.ts")).exists()).toBe(true)
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `.oxfmtrc.json` to `oxfmt.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -631,6 +631,10 @@ describe("doctor", () => {
     expect(Exit.isFailure(exit)).toBe(true)
     expect(error).toMatchObject({ _tag: "InvalidConfigFormat" })
     expect(errorPath).toEndWith("/.oxfmtrc.json")
+    expect(prompter.spinnerEntries).toContainEqual({
+      message: 'Migration "Legacy oxfmt JSON config" failed, files restored.',
+      type: "stop",
+    })
     expect(prompter.outros).toEqual(["❌ Doctor failed"])
   })
 
@@ -672,9 +676,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${oxfmt.name}@${oxfmt.version}\`.`,
     })
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `.oxfmtrc.json` to `oxfmt.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -790,9 +794,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, "knip.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "knip.config.ts")).exists()).toBe(true)
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `knip.json` to `knip.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -838,9 +842,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${knip.name}@${knip.version}\`.`,
     })
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `knip.json` to `knip.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -959,9 +963,9 @@ describe("doctor", () => {
     expect(installer.calls).toEqual([])
     expect(await Bun.file(join(tempDir, ".oxlintrc.json")).exists()).toBe(false)
     expect(await Bun.file(join(tempDir, "oxlint.config.ts")).exists()).toBe(true)
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `.oxlintrc.json` to `oxlint.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })
@@ -1008,9 +1012,9 @@ describe("doctor", () => {
       level: "success",
       message: `Fixed: installed \`${oxlint.name}@${oxlint.version}\`.`,
     })
-    expect(prompter.logs).toContainEqual({
-      level: "success",
+    expect(prompter.spinnerEntries).toContainEqual({
       message: "Fixed: Migrate legacy `.oxlintrc.json` to `oxlint.config.ts`.",
+      type: "stop",
     })
     expect(prompter.outros).toEqual(["✅ Doctor completed successfully!"])
   })

--- a/src/commands/__tests__/update.test.ts
+++ b/src/commands/__tests__/update.test.ts
@@ -13,6 +13,7 @@ import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import sherif from "#lib/integrations/tooling/sherif.ts"
 import tsgolint from "#lib/integrations/tooling/tsgolint.ts"
 import { FailedToInstallDependency } from "#lib/shared/errors.ts"
+import { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 import {
   createDependencyInstallerTestContext,
   createPrompterTestContext,
@@ -402,6 +403,40 @@ describe("update", () => {
         prompter.logs.filter((entry) => entry.level === "success").map((entry) => entry.message)
       ).toEqual(["Migrations ran successfully.", "Dependencies updated successfully."])
       expect(prompter.outros).toEqual(["✅ Update completed successfully!"])
+    })
+
+    test("surface migration warnings during a monorepo typecheck migration", async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            devDependencies: {
+              oxlint: oxlint.version,
+              "oxlint-tsgolint": tsgolint.version,
+            },
+            name: "test-project",
+            scripts: {
+              typecheck: "adamantite typecheck",
+            },
+            version: "1.0.0",
+            workspaces: ["packages/*"],
+          },
+          null,
+          2
+        )
+      )
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(updateCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(await Bun.file(join(tempDir, "tsconfig.json")).exists()).toBe(false)
+
+      for (const message of MONOREPO_GUIDANCE) {
+        expect(prompter.logs).toContainEqual({ level: "warning", message })
+      }
     })
 
     test("enable type-checked linting in an existing oxlint.config.ts during typecheck migration", async () => {

--- a/src/commands/__tests__/update.test.ts
+++ b/src/commands/__tests__/update.test.ts
@@ -405,6 +405,53 @@ describe("update", () => {
       expect(prompter.outros).toEqual(["✅ Update completed successfully!"])
     })
 
+    test("skip warning about a workflow that an earlier migration already regenerated", async () => {
+      await writeFile(
+        join(tempDir, "package.json"),
+        JSON.stringify(
+          {
+            devDependencies: {
+              oxlint: oxlint.version,
+              "oxlint-tsgolint": tsgolint.version,
+            },
+            name: "test-project",
+            scripts: {
+              typecheck: "adamantite typecheck",
+            },
+            version: "1.0.0",
+          },
+          null,
+          2
+        )
+      )
+      await writeFile(join(tempDir, ".node-version"), "22.19.0\n")
+      mkdirSync(join(tempDir, ".github", "workflows"), { recursive: true })
+      await writeFile(
+        join(tempDir, ".github", "workflows", "adamantite.yml"),
+        'name: adamantite\njobs:\n  verify:\n    steps:\n      - uses: actions/setup-node@v7\n        with:\n          node-version: "26"\n'
+      )
+
+      const prompter = createPrompterTestContext()
+      const installer = createDependencyInstallerTestContext()
+
+      const exit = await runCommand(updateCommand, [], [prompter.layer, installer.layer])
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      // The typecheck migration adds the `check` script and regenerates the workflow, so the
+      // node-version migration's check must see that state instead of warning from a stale one.
+      const workflow = await readFile(
+        join(tempDir, ".github", "workflows", "adamantite.yml"),
+        "utf8"
+      )
+      expect(workflow).not.toContain('node-version: "26"')
+      expect(prompter.logs).not.toContainEqual({
+        level: "warning",
+        message:
+          "No CI-compatible managed scripts were found, so the GitHub Actions workflow was not updated.",
+      })
+    })
+
     test("surface migration warnings during a monorepo typecheck migration", async () => {
       await writeFile(
         join(tempDir, "package.json"),

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -148,7 +148,13 @@ export default Command.make("doctor", { fix }).pipe(
               continue
             }
 
-            yield* runMigration(migration, { cwd })
+            const result = yield* runMigration(migration, { cwd })
+
+            for (const warning of result.warnings) {
+              yield* prompter.log.warning(warning)
+            }
+
+            yield* prompter.log.success(`Fixed: ${action.description}`)
             appliedActions.add(entry)
           }
         }).pipe(

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -148,13 +148,29 @@ export default Command.make("doctor", { fix }).pipe(
               continue
             }
 
-            const result = yield* runMigration(migration, { cwd })
+            // Same gate as `update`: check() alone decides whether migrate runs, re-evaluated
+            // against the current workspace state rather than the assessment snapshot.
+            const checkResult = yield* migration.check({ cwd })
+
+            for (const warning of checkResult.warnings) {
+              yield* prompter.log.warning(warning)
+            }
+
+            if (checkResult.status !== "needed") {
+              appliedActions.add(entry)
+              continue
+            }
+
+            const result = yield* prompter.withSpinner(() => runMigration(migration, { cwd }), {
+              failure: `Migration "${migration.title}" failed, files restored.`,
+              start: checkResult.summary,
+              success: `Fixed: ${action.description}`,
+            })
 
             for (const warning of result.warnings) {
               yield* prompter.log.warning(warning)
             }
 
-            yield* prompter.log.success(`Fixed: ${action.description}`)
             appliedActions.add(entry)
           }
         }).pipe(

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -98,13 +98,19 @@ export default Command.make("update").pipe(
           continue
         }
 
-        yield* prompter.log.info(result.summary)
+        const runResult = yield* prompter.withSpinner(
+          () => runMigration(migration, migrationContext),
+          {
+            failure: `Migration "${migration.title}" failed, files restored.`,
+            start: result.summary,
+            success: `Migration "${migration.title}" completed successfully.`,
+          }
+        )
 
-        yield* runMigration(migration, migrationContext, {
-          onRestore: prompter.log.warning(
-            `Migration "${migration.title}" failed, restoring files...`
-          ),
-        })
+        for (const warning of runResult.warnings) {
+          yield* prompter.log.warning(warning)
+        }
+
         migratedIds.push(migration.id)
       }
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,7 +2,6 @@ import process from "node:process"
 import type { PackageJson } from "type-fest"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
-import { pipe } from "effect/Function"
 import * as Result from "effect/Result"
 import * as Command from "effect/unstable/cli/Command"
 import type { ToolingPackage } from "#lib/integrations/base.ts"
@@ -73,28 +72,34 @@ export default Command.make("update").pipe(
 
       const assessments = yield* collectAssessments()
 
-      const migrationChecks = yield* pipe(
-        migrations.filter((candidate) => candidate.tags.includes("update")),
-        Effect.forEach((migration) =>
-          migration.check(migrationContext).pipe(Effect.map((result) => ({ migration, result })))
-        )
-      )
+      // Assessments, checks, and migrations derive warnings from the same detected state, so a
+      // shared Set collapses the overlap.
+      const printedWarnings = new Set<string>()
 
-      // Assessments and migration checks derive warnings from the same detected state, so a Set
-      // collapses the overlap.
-      const warnings = new Set([
-        ...assessments.flatMap(({ assessment }) => assessment.warnings),
-        ...migrationChecks.flatMap(({ result }) => result.warnings),
-      ])
+      const printWarnings = (warnings: readonly string[]) =>
+        Effect.gen(function* () {
+          for (const warning of warnings) {
+            if (printedWarnings.has(warning)) {
+              continue
+            }
 
-      for (const warning of warnings) {
-        yield* prompter.log.warning(warning)
-      }
+            printedWarnings.add(warning)
+            yield* prompter.log.warning(warning)
+          }
+        })
+
+      yield* printWarnings(assessments.flatMap(({ assessment }) => assessment.warnings))
 
       const migratedIds: string[] = []
 
-      for (const { migration, result } of migrationChecks) {
-        if (result.status !== "needed") {
+      // Each check runs immediately before its migration: earlier migrations change the
+      // workspace, so a batched up-front check would decide from stale state.
+      for (const migration of migrations.filter((candidate) => candidate.tags.includes("update"))) {
+        const checkResult = yield* migration.check(migrationContext)
+
+        yield* printWarnings(checkResult.warnings)
+
+        if (checkResult.status !== "needed") {
           continue
         }
 
@@ -102,14 +107,12 @@ export default Command.make("update").pipe(
           () => runMigration(migration, migrationContext),
           {
             failure: `Migration "${migration.title}" failed, files restored.`,
-            start: result.summary,
+            start: checkResult.summary,
             success: `Migration "${migration.title}" completed successfully.`,
           }
         )
 
-        for (const warning of runResult.warnings) {
-          yield* prompter.log.warning(warning)
-        }
+        yield* printWarnings(runResult.warnings)
 
         migratedIds.push(migration.id)
       }

--- a/src/lib/migrations/__tests__/base.test.ts
+++ b/src/lib/migrations/__tests__/base.test.ts
@@ -27,6 +27,20 @@ describe("runMigration", () => {
     rmSync(tempDir, { force: true, recursive: true })
   })
 
+  test("return the migrate result", async () => {
+    const migration = defineMigration({
+      check: () => Effect.succeed({ status: "not-applicable" as const, warnings: [] }),
+      id: "reporting-migration",
+      migrate: () => Effect.succeed({ warnings: ["something to surface"] }),
+      tags: ["update"],
+      title: "Reporting migration",
+    })
+
+    const result = await runTestEffect(runMigration(migration, { cwd: tempDir }))
+
+    expect(result).toEqual({ warnings: ["something to surface"] })
+  })
+
   test("restore tracked files when migrate fails", async () => {
     await Bun.write("existing.txt", "before\n")
 
@@ -60,7 +74,10 @@ describe("runMigration", () => {
       check: () => Effect.succeed({ status: "not-applicable" as const, warnings: [] }),
       files: ["existing.txt"],
       id: "invalid-migration",
-      migrate: () => Effect.promise(() => Bun.write("existing.txt", "after\n")),
+      migrate: () =>
+        Effect.promise(() => Bun.write("existing.txt", "after\n")).pipe(
+          Effect.as({ warnings: [] })
+        ),
       tags: ["update"],
       title: "Invalid migration",
       validate: () =>

--- a/src/lib/migrations/__tests__/hardcoded-node-version.test.ts
+++ b/src/lib/migrations/__tests__/hardcoded-node-version.test.ts
@@ -6,10 +6,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun from "bun"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import {
-  createDependencyInstallerTestContext,
-  createPrompterTestContext,
-} from "#commands/__tests__/command-test-helpers.ts"
+import { createDependencyInstallerTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationHardcodedNodeVersion from "#lib/migrations/hardcoded-node-version.ts"
 import { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
 
@@ -28,14 +25,12 @@ function runTestEffect<A, E, R>(
   effect: Effect.Effect<A, E, R>,
   options?: Parameters<typeof createDependencyInstallerTestContext>[0]
 ) {
-  const prompterContext = createPrompterTestContext()
   const dependencyInstallerContext = createDependencyInstallerTestContext(options)
   const provided = effect.pipe(
     Effect.provide(
       Layer.mergeAll(
         NodeServices.layer,
         NodeVersionResolver.layer.pipe(Layer.provide(NodeServices.layer)),
-        prompterContext.layer,
         dependencyInstallerContext.layer
       )
     )
@@ -140,7 +135,7 @@ describe("hardcodedNodeVersion", () => {
     await runTestEffect(migrationHardcodedNodeVersion.validate({ cwd: tempDir }))
   })
 
-  test("migrate leaves the workflow unchanged without CI-compatible managed scripts", async () => {
+  test("check reports not-applicable with a warning without CI-compatible managed scripts", async () => {
     await Bun.write(
       "package.json",
       JSON.stringify({ name: "test-project", version: "1.0.0" }, null, 2)
@@ -148,26 +143,49 @@ describe("hardcodedNodeVersion", () => {
     mkdirSync(".github/workflows", { recursive: true })
     await Bun.write(".github/workflows/adamantite.yml", HARDCODED_WORKFLOW)
 
-    await runTestEffect(migrationHardcodedNodeVersion.migrate({ cwd: tempDir }))
+    const result = await runTestEffect(migrationHardcodedNodeVersion.check({ cwd: tempDir }))
 
-    const workflow = await Bun.file(".github/workflows/adamantite.yml").text()
-    expect(workflow).toBe(HARDCODED_WORKFLOW)
-
-    await runTestEffect(migrationHardcodedNodeVersion.validate({ cwd: tempDir }))
-  })
-
-  test("migrate leaves the workflow unchanged for an unsupported package manager", async () => {
-    await writeManagedProject()
-
-    await runTestEffect(migrationHardcodedNodeVersion.migrate({ cwd: tempDir }), {
-      detectedPackageManager: { name: "aube" },
+    expect(result).toEqual({
+      status: "not-applicable",
+      warnings: [
+        "No CI-compatible managed scripts were found, so the GitHub Actions workflow was not updated.",
+      ],
     })
 
     const workflow = await Bun.file(".github/workflows/adamantite.yml").text()
     expect(workflow).toBe(HARDCODED_WORKFLOW)
+  })
 
-    await runTestEffect(migrationHardcodedNodeVersion.validate({ cwd: tempDir }), {
+  test("check reports not-applicable with a warning for an unsupported package manager", async () => {
+    await writeManagedProject()
+
+    const result = await runTestEffect(migrationHardcodedNodeVersion.check({ cwd: tempDir }), {
       detectedPackageManager: { name: "aube" },
+    })
+
+    expect(result).toEqual({
+      status: "not-applicable",
+      warnings: [
+        "`aube` is not a supported package manager for CI workflow generation, so the GitHub Actions workflow was not updated.",
+      ],
+    })
+
+    const workflow = await Bun.file(".github/workflows/adamantite.yml").text()
+    expect(workflow).toBe(HARDCODED_WORKFLOW)
+  })
+
+  test("check reports not-applicable with a warning when no package manager is detected", async () => {
+    await writeManagedProject()
+
+    const result = await runTestEffect(migrationHardcodedNodeVersion.check({ cwd: tempDir }), {
+      detectedPackageManager: null,
+    })
+
+    expect(result).toEqual({
+      status: "not-applicable",
+      warnings: [
+        "Could not detect a package manager, so the GitHub Actions workflow was not updated.",
+      ],
     })
   })
 })

--- a/src/lib/migrations/__tests__/legacy-knip-json.test.ts
+++ b/src/lib/migrations/__tests__/legacy-knip-json.test.ts
@@ -5,15 +5,10 @@ import { join } from "node:path"
 import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun from "bun"
 import * as Effect from "effect/Effect"
-import * as Layer from "effect/Layer"
-import { createPrompterTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationLegacyKnipJson from "#lib/migrations/legacy-knip-json.ts"
 
 function runTestEffect<A, E, R>(effect: Effect.Effect<A, E, R>) {
-  const prompterContext = createPrompterTestContext()
-  const provided = effect.pipe(
-    Effect.provide(Layer.merge(NodeServices.layer, prompterContext.layer))
-  ) as Effect.Effect<A, E>
+  const provided = effect.pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<A, E>
 
   return Effect.runPromise(provided)
 }

--- a/src/lib/migrations/__tests__/legacy-oxfmt-json.test.ts
+++ b/src/lib/migrations/__tests__/legacy-oxfmt-json.test.ts
@@ -5,15 +5,10 @@ import { join } from "node:path"
 import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun from "bun"
 import * as Effect from "effect/Effect"
-import * as Layer from "effect/Layer"
-import { createPrompterTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationLegacyOxfmtJson from "#lib/migrations/legacy-oxfmt-json.ts"
 
 function runTestEffect<A, E, R>(effect: Effect.Effect<A, E, R>) {
-  const prompterContext = createPrompterTestContext()
-  const provided = effect.pipe(
-    Effect.provide(Layer.merge(NodeServices.layer, prompterContext.layer))
-  ) as Effect.Effect<A, E>
+  const provided = effect.pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<A, E>
 
   return Effect.runPromise(provided)
 }

--- a/src/lib/migrations/__tests__/legacy-oxlint-json.test.ts
+++ b/src/lib/migrations/__tests__/legacy-oxlint-json.test.ts
@@ -5,15 +5,10 @@ import { join } from "node:path"
 import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun from "bun"
 import * as Effect from "effect/Effect"
-import * as Layer from "effect/Layer"
-import { createPrompterTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationLegacyOxlintJson from "#lib/migrations/legacy-oxlint-json.ts"
 
 function runTestEffect<A, E, R>(effect: Effect.Effect<A, E, R>) {
-  const prompterContext = createPrompterTestContext()
-  const provided = effect.pipe(
-    Effect.provide(Layer.merge(NodeServices.layer, prompterContext.layer))
-  ) as Effect.Effect<A, E>
+  const provided = effect.pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<A, E>
   return Effect.runPromise(provided)
 }
 

--- a/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
+++ b/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
@@ -6,26 +6,19 @@ import * as NodeServices from "@effect/platform-node/NodeServices"
 import Bun from "bun"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import {
-  createDependencyInstallerTestContext,
-  createPrompterTestContext,
-} from "#commands/__tests__/command-test-helpers.ts"
+import { createDependencyInstallerTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationLegacyOxlintJson from "#lib/migrations/legacy-oxlint-json.ts"
 import migrationLegacyTypecheckScript from "#lib/migrations/legacy-typecheck-script.ts"
 import { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
 import { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
 
-function runTestEffect<A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  prompterContext = createPrompterTestContext()
-) {
+function runTestEffect<A, E, R>(effect: Effect.Effect<A, E, R>) {
   const dependencyInstallerContext = createDependencyInstallerTestContext()
   const provided = effect.pipe(
     Effect.provide(
       Layer.mergeAll(
         NodeServices.layer,
         NodeVersionResolver.layer.pipe(Layer.provide(NodeServices.layer)),
-        prompterContext.layer,
         dependencyInstallerContext.layer
       )
     )
@@ -202,7 +195,7 @@ describe("legacyTypecheckScript", () => {
     expect(tsconfig.extends).toBe("adamantite/typescript")
   })
 
-  test("migrate prints guidance instead of writing a root tsconfig in a monorepo", async () => {
+  test("migrate returns guidance instead of writing a root tsconfig in a monorepo", async () => {
     await Bun.write(
       "package.json",
       JSON.stringify(
@@ -219,14 +212,10 @@ describe("legacyTypecheckScript", () => {
       )
     )
 
-    const prompterContext = createPrompterTestContext()
-    await runTestEffect(migrationLegacyTypecheckScript.migrate({ cwd: tempDir }), prompterContext)
+    const result = await runTestEffect(migrationLegacyTypecheckScript.migrate({ cwd: tempDir }))
 
     expect(await Bun.file("tsconfig.json").exists()).toBe(false)
-
-    for (const message of MONOREPO_GUIDANCE) {
-      expect(prompterContext.logs).toContainEqual({ level: "info", message })
-    }
+    expect(result.warnings).toEqual([...MONOREPO_GUIDANCE])
 
     await runTestEffect(migrationLegacyTypecheckScript.validate({ cwd: tempDir }))
   })

--- a/src/lib/migrations/base.ts
+++ b/src/lib/migrations/base.ts
@@ -16,7 +16,6 @@ import type {
 } from "#lib/shared/errors.ts"
 import type { DependencyInstaller } from "#lib/workspace/dependency-installer.ts"
 import type { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
-import type { Prompter } from "#terminal/prompter.ts"
 
 export interface MigrationContext {
   readonly cwd: string
@@ -54,7 +53,13 @@ export type MigrationRequirements =
   | FileSystem.FileSystem
   | NodeVersionResolver
   | Path.Path
-  | Prompter
+
+export interface MigrationRunResult {
+  /**
+   * Messages for the command layer to surface; migrations never print themselves.
+   */
+  readonly warnings: readonly string[]
+}
 
 export interface Migration {
   readonly id: string
@@ -64,7 +69,12 @@ export interface Migration {
   check(
     context: MigrationContext
   ): Effect.Effect<MigrationCheckResult, MigrationError, MigrationRequirements>
-  migrate(context: MigrationContext): Effect.Effect<void, MigrationError, MigrationRequirements>
+  /**
+   * Applies the migration unconditionally: `check` alone decides whether it runs.
+   */
+  migrate(
+    context: MigrationContext
+  ): Effect.Effect<MigrationRunResult, MigrationError, MigrationRequirements>
   validate?(context: MigrationContext): Effect.Effect<void, MigrationError, MigrationRequirements>
 }
 
@@ -72,13 +82,7 @@ export function defineMigration<const T extends Migration>(migration: T): T {
   return migration
 }
 
-export function runMigration(
-  migration: Migration,
-  context: MigrationContext,
-  options?: {
-    readonly onRestore?: Effect.Effect<void>
-  }
-) {
+export function runMigration(migration: Migration, context: MigrationContext) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
@@ -97,14 +101,10 @@ export function runMigration(
       }
     }
 
-    yield* migration.migrate(context).pipe(
-      Effect.andThen(() => migration.validate?.(context) ?? Effect.void),
+    return yield* migration.migrate(context).pipe(
+      Effect.tap(() => migration.validate?.(context) ?? Effect.void),
       Effect.onError(() =>
         Effect.gen(function* () {
-          if (options?.onRestore) {
-            yield* options.onRestore
-          }
-
           for (const [fullPath, content] of snapshot) {
             if (content !== null) {
               yield* fs.writeFileString(fullPath, content).pipe(Effect.ignore)

--- a/src/lib/migrations/hardcoded-node-version.ts
+++ b/src/lib/migrations/hardcoded-node-version.ts
@@ -11,7 +11,6 @@ import {
   getManagedScripts,
   readPackageJson,
 } from "#lib/workspace/package-json.ts"
-import { Prompter } from "#terminal/prompter.ts"
 
 const HARDCODED_NODE_VERSION_REGEX = /^\s*node-version:\s*"?\d/m
 
@@ -75,6 +74,19 @@ export default defineMigration({
         return { status: "not-applicable", warnings: [] } as const
       }
 
+      const regeneration = yield* canRegenerateWorkflow(context.cwd)
+
+      if (!regeneration.supported) {
+        const warning =
+          regeneration.reason === "scripts"
+            ? "No CI-compatible managed scripts were found, so the GitHub Actions workflow was not updated."
+            : regeneration.reason === "no-package-manager"
+              ? "Could not detect a package manager, so the GitHub Actions workflow was not updated."
+              : `\`${regeneration.packageManagerName}\` is not a supported package manager for CI workflow generation, so the GitHub Actions workflow was not updated.`
+
+        return { status: "not-applicable", warnings: [warning] } as const
+      }
+
       return {
         status: "needed",
         summary:
@@ -86,47 +98,18 @@ export default defineMigration({
   id: "hardcoded-node-version",
   migrate: (context) =>
     Effect.gen(function* () {
-      const prompter = yield* Prompter
+      const regeneration = yield* canRegenerateWorkflow(context.cwd)
 
-      const runMigration = Effect.gen(function* () {
-        const workflow = yield* readWorkflow(context.cwd)
+      if (!regeneration.supported) {
+        return yield* Effect.die(new Error("check() guaranteed workflow regeneration is supported"))
+      }
 
-        if (workflow === null || !HARDCODED_NODE_VERSION_REGEX.test(workflow)) {
-          return "noop" as const
-        }
-
-        const regeneration = yield* canRegenerateWorkflow(context.cwd)
-
-        if (!regeneration.supported) {
-          const warning =
-            regeneration.reason === "scripts"
-              ? "No CI-compatible managed scripts were found, so the GitHub Actions workflow was not updated."
-              : regeneration.reason === "no-package-manager"
-                ? "Could not detect a package manager, so the GitHub Actions workflow was not updated."
-                : `\`${regeneration.packageManagerName}\` is not a supported package manager for CI workflow generation, so the GitHub Actions workflow was not updated.`
-
-          yield* prompter.log.warning(warning)
-          return "noop" as const
-        }
-
-        yield* github.update(context.cwd, {
-          packageManager: regeneration.packageManager,
-          scripts: regeneration.scripts,
-        })
-
-        return "migrated" as const
+      yield* github.update(context.cwd, {
+        packageManager: regeneration.packageManager,
+        scripts: regeneration.scripts,
       })
 
-      yield* prompter
-        .withSpinner(() => runMigration, {
-          failure: "Failed to update the GitHub Actions workflow Node.js version.",
-          start: "Updating the GitHub Actions workflow Node.js version...",
-          success: (status) =>
-            status === "noop"
-              ? "No migration needed."
-              : "GitHub Actions workflow Node.js version updated successfully.",
-        })
-        .pipe(Effect.asVoid)
+      return { warnings: [] }
     }),
   tags: ["update"],
   title: "Hard-coded workflow Node.js version",
@@ -134,13 +117,7 @@ export default defineMigration({
     Effect.gen(function* () {
       const workflow = yield* readWorkflow(context.cwd)
 
-      if (workflow === null || !HARDCODED_NODE_VERSION_REGEX.test(workflow)) {
-        return
-      }
-
-      const regeneration = yield* canRegenerateWorkflow(context.cwd)
-
-      if (regeneration.supported) {
+      if (workflow !== null && HARDCODED_NODE_VERSION_REGEX.test(workflow)) {
         return yield* new MigrationValidationFailed({
           migrationId: "hardcoded-node-version",
           reason: "The GitHub Actions workflow still contains a hard-coded Node.js version.",

--- a/src/lib/migrations/legacy-json-config.ts
+++ b/src/lib/migrations/legacy-json-config.ts
@@ -13,7 +13,6 @@ import {
   MigrationValidationFailed,
 } from "#lib/shared/errors.ts"
 import { parseJson } from "#lib/shared/json.ts"
-import { Prompter } from "#terminal/prompter.ts"
 
 interface LegacyJsonConfigIntegration {
   readonly config: string
@@ -48,7 +47,9 @@ function migrateLegacyJsonConfig(cwd: string, options: LegacyJsonConfigMigration
     const state = yield* options.integration.detect(cwd)
 
     if (state.active === null || state.active.format === "ts") {
-      return
+      return yield* Effect.die(
+        new Error(`check() guaranteed a legacy ${options.displayName} config exists`)
+      )
     }
 
     const legacyConfigPath = state.active.path
@@ -76,6 +77,8 @@ function migrateLegacyJsonConfig(cwd: string, options: LegacyJsonConfigMigration
           Effect.mapError((cause) => new FailedToDeleteFile({ cause, path: legacyConfig.path }))
         )
     }
+
+    return { warnings: [] }
   })
 }
 
@@ -101,21 +104,7 @@ export function defineLegacyJsonConfigMigration(options: LegacyJsonConfigMigrati
       }),
     files: options.integration.files.map((file) => file.path),
     id: options.id,
-    migrate: (context) =>
-      Effect.gen(function* () {
-        const prompter = yield* Prompter
-        const state = yield* options.integration.detect(context.cwd)
-        const legacyConfigFile =
-          state.active !== null && state.active.format !== "ts"
-            ? state.active.file
-            : (options.integration.files[1]?.path ?? options.integration.config)
-
-        yield* prompter.withSpinner(() => migrateLegacyJsonConfig(context.cwd, options), {
-          failure: `Failed to migrate ${legacyConfigFile}.`,
-          start: `Migrating \`${legacyConfigFile}\` to \`${options.integration.config}\`...`,
-          success: `${options.displayName} config migrated to \`${options.integration.config}\` successfully.`,
-        })
-      }),
+    migrate: (context) => migrateLegacyJsonConfig(context.cwd, options),
     tags: ["update"],
     title: options.title,
     validate: (context) =>

--- a/src/lib/migrations/legacy-typecheck-script.ts
+++ b/src/lib/migrations/legacy-typecheck-script.ts
@@ -82,6 +82,10 @@ export default defineMigration({
       const packageJson = yield* readPackageJson(context.cwd)
       const migratedPackageJson = migrateLegacyTypecheckScriptPackageJson(packageJson)
 
+      if (!migratedPackageJson.migrated) {
+        return yield* Effect.die(new Error("check() guaranteed the legacy typecheck script exists"))
+      }
+
       yield* writePackageJson(context.cwd, migratedPackageJson.packageJson)
 
       const oxlintState = yield* oxlint.detect(context.cwd)

--- a/src/lib/migrations/legacy-typecheck-script.ts
+++ b/src/lib/migrations/legacy-typecheck-script.ts
@@ -1,6 +1,5 @@
 import type { PackageJson } from "type-fest"
 import * as Effect from "effect/Effect"
-import { pipe } from "effect/Function"
 import github from "#lib/integrations/ci/github.ts"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
@@ -16,7 +15,6 @@ import {
   MANAGED_SCRIPT_COMMANDS,
 } from "#lib/workspace/package-json.ts"
 import tsconfig, { MONOREPO_GUIDANCE } from "#lib/workspace/tsconfig.ts"
-import { Prompter } from "#terminal/prompter.ts"
 
 const LEGACY_TYPECHECK_SCRIPT_COMMAND = "adamantite typecheck"
 
@@ -78,88 +76,54 @@ export default defineMigration({
   id: "legacy-typecheck-script",
   migrate: (context) =>
     Effect.gen(function* () {
-      const prompter = yield* Prompter
       const dependencyInstaller = yield* DependencyInstaller
+      const warnings: string[] = []
 
-      const runMigration = Effect.gen(function* () {
-        const packageJson = yield* readPackageJson(context.cwd)
-        const migratedPackageJson = migrateLegacyTypecheckScriptPackageJson(packageJson)
+      const packageJson = yield* readPackageJson(context.cwd)
+      const migratedPackageJson = migrateLegacyTypecheckScriptPackageJson(packageJson)
 
-        if (!migratedPackageJson.migrated) {
-          return "noop" as const
-        }
+      yield* writePackageJson(context.cwd, migratedPackageJson.packageJson)
 
-        yield* writePackageJson(context.cwd, migratedPackageJson.packageJson)
+      const oxlintState = yield* oxlint.detect(context.cwd)
 
-        const oxlintState = yield* oxlint.detect(context.cwd)
+      if (oxlintState.active === null) {
+        yield* oxlint.create(context.cwd)
+      } else if (oxlintState.active.format === "ts") {
+        yield* oxlint.update(context.cwd)
+      }
 
-        if (oxlintState.active === null) {
-          yield* oxlint.create(context.cwd)
-        } else if (oxlintState.active.format === "ts") {
-          yield* oxlint.update(context.cwd)
-        }
+      const isMonorepo = yield* checkIsMonorepo(context.cwd)
 
-        const isMonorepo = yield* checkIsMonorepo(context.cwd)
+      if (isMonorepo) {
+        warnings.push(...MONOREPO_GUIDANCE)
+      } else {
+        const hasTypescriptConfig = yield* tsconfig.detect(context.cwd)
+        yield* hasTypescriptConfig ? tsconfig.update(context.cwd) : tsconfig.create(context.cwd)
+      }
 
-        if (isMonorepo) {
-          yield* pipe(
-            MONOREPO_GUIDANCE,
-            Effect.forEach((line) => prompter.log.info(line))
+      const workflowExists = yield* github.detect(context.cwd)
+      const managedScripts = getManagedScripts(migratedPackageJson.packageJson)
+
+      if (workflowExists && hasCICompatibleScripts(managedScripts)) {
+        const detectedPackageManager = yield* dependencyInstaller.detectPackageManager(context.cwd)
+
+        if (detectedPackageManager && checkIsSupportedPackageManager(detectedPackageManager.name)) {
+          yield* github.update(context.cwd, {
+            packageManager: detectedPackageManager.name,
+            scripts: managedScripts,
+          })
+        } else if (detectedPackageManager) {
+          warnings.push(
+            `\`${detectedPackageManager.name}\` is not a supported package manager for CI workflow generation, so the GitHub Actions workflow was not updated.`
           )
         } else {
-          const hasTypescriptConfig = yield* tsconfig.detect(context.cwd)
-          yield* hasTypescriptConfig ? tsconfig.update(context.cwd) : tsconfig.create(context.cwd)
-        }
-
-        const workflowExists = yield* github.detect(context.cwd)
-        const managedScripts = getManagedScripts(migratedPackageJson.packageJson)
-
-        if (workflowExists && hasCICompatibleScripts(managedScripts)) {
-          const detectedPackageManager = yield* dependencyInstaller.detectPackageManager(
-            context.cwd
+          warnings.push(
+            "Could not detect a package manager, so the GitHub Actions workflow was not updated."
           )
-
-          if (
-            detectedPackageManager &&
-            checkIsSupportedPackageManager(detectedPackageManager.name)
-          ) {
-            const packageManagerName = detectedPackageManager.name
-            yield* prompter.withSpinner(
-              () =>
-                github.update(context.cwd, {
-                  packageManager: packageManagerName,
-                  scripts: managedScripts,
-                }),
-              {
-                failure: "Failed to update GitHub Actions workflow.",
-                start: "Updating GitHub Actions workflow...",
-                success: "GitHub Actions workflow updated successfully",
-              }
-            )
-          } else if (detectedPackageManager) {
-            yield* prompter.log.warning(
-              `\`${detectedPackageManager.name}\` is not a supported package manager for CI workflow generation, so the GitHub Actions workflow was not updated.`
-            )
-          } else {
-            yield* prompter.log.warning(
-              "Could not detect a package manager, so the GitHub Actions workflow was not updated."
-            )
-          }
         }
+      }
 
-        return "migrated" as const
-      })
-
-      yield* prompter
-        .withSpinner(() => runMigration, {
-          failure: "Legacy `typecheck` script migration failed.",
-          start: "Migrating `typecheck` script to unified `check` command...",
-          success: (status) =>
-            status === "noop"
-              ? "No migration needed."
-              : "Legacy `typecheck` script migrated to `check` successfully.",
-        })
-        .pipe(Effect.asVoid)
+      return { warnings }
     }),
   tags: ["update"],
   title: "Legacy typecheck script",


### PR DESCRIPTION
Closes #367.

Implements the issue with one structural revision to its plan: instead of relocating the migrations' spinner copy and noop handling across the boundary, this collapses them. `check()` alone decides whether a migration runs; `migrate()` acts unconditionally and returns data.

## What changed

- **`lib/migrations/base.ts`** — `Prompter` dropped from `MigrationRequirements`, so migrations can no longer reach the terminal at the type level. `migrate` returns a `MigrationRunResult` — just `{ warnings }`; the planned `"migrated" | "noop"` status enum is gone because a migration that only runs when needed has nothing to noop about. `runMigration` returns the result and loses the `onRestore` print-callback (the command reports failure/restoration itself).
- **`hardcoded-node-version`** — the `canRegenerateWorkflow` probing moves from `migrate` into `check`, which now returns `not-applicable` with the blocking reason as a warning. `validate`'s inverted "fail only if regeneration is supported" re-check collapses to a plain assertion.
- **`legacy-typecheck-script`** — the nested spinner (a spinner inside a spinner — clack spinners aren't reentrant) is deleted, not relocated. `MONOREPO_GUIDANCE` and package-manager caveats come back as warnings.
- **`legacy-json-config`** — `migrate` is a one-line delegation; the noop guard and the `files[1]?.path ?? config` filename fallback existed only to feed spinner copy and died with it.
- **`commands/update.ts`** — owns one spinner per migration: start text is the check summary (previously printed *and* duplicated by the migration's own spinner), success/failure derived from the migration title, returned warnings printed after.
- **`commands/doctor.ts`** — also runs migrations; now prints returned warnings and a `Fixed: <action description>` line matching its existing convention.
- **`oxlint.config.ts`** — `no-restricted-imports` override bans `#terminal/*` under `src/lib/**` (belt-and-suspenders for non-migration lib code; verified it fires by planting a violation).
- **Tests** — migration tests drop their Prompter stub layers and assert returned warnings as data; the two "migrate leaves the workflow unchanged" scenarios became check-level tests; update tests gained an end-to-end assertion that migration warnings surface through the command.

## Outcome

`grep '#terminal/' src/lib` returns nothing; detection runs per migration drop from four to two; 348 tests pass, `bun run check` and `bun run format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)