### PR TITLE
Surface init CI setup failures and cut redundant work in doctor and update

### DIFF
--- a/.changeset/eight-lions-refuse.md
+++ b/.changeset/eight-lions-refuse.md
@@ -1,0 +1,5 @@
+---
+"adamantite": patch
+---
+
+Surface GitHub Actions setup failures during `adamantite init` instead of silently continuing. When the workflow cannot be written, `init` now warns with the underlying reason and a recovery hint. `doctor` and `update` also assess integrations concurrently and read `package.json` once per assessment pass instead of once per integration.

--- a/src/__tests__/filesystem.ts
+++ b/src/__tests__/filesystem.ts
@@ -170,11 +170,18 @@ export function createFileSystemTestContext(options?: {
     readFile: makeUnimplemented("readFile"),
     readFileString: (path) =>
       Effect.suspend(() => {
-        const content = files.get(normalize(path))
+        const target = normalize(path)
+        const content = files.get(target)
 
-        return content === undefined
-          ? Effect.fail(makeSystemError("NotFound", "readFileString", path))
-          : Effect.succeed(content)
+        if (content !== undefined) {
+          return Effect.succeed(content)
+        }
+
+        // The Node backend maps EISDIR to BadResource, so reading a directory must not report
+        // NotFound: NotFound means the path can be treated as absent.
+        return directories.has(target)
+          ? Effect.fail(makeSystemError("BadResource", "readFileString", path))
+          : Effect.fail(makeSystemError("NotFound", "readFileString", path))
       }),
     readLink: makeUnimplemented("readLink"),
     realPath: makeUnimplemented("realPath"),

--- a/src/commands/__tests__/init.test.ts
+++ b/src/commands/__tests__/init.test.ts
@@ -1389,6 +1389,44 @@ describe("init", () => {
       })
     )
 
+    it.effect("continues initialization when the GitHub Actions workflow cannot be written", () =>
+      Effect.gen(function* () {
+        const files = createInitTestContext()
+        const workflowPath = ".github/workflows/adamantite.yml"
+        files.makeReadOnly(workflowPath)
+
+        const prompter = createPrompterTestContext({
+          confirmResponses: [false, true, false],
+          multiselectResponses: [["check"], [], []],
+        })
+        const installer = createDependencyInstallerTestContext()
+
+        const exit = yield* runCommand(initCommand, [], {
+          files,
+          layers: [prompter.layer, installer.layer],
+        })
+
+        expect(Exit.isSuccess(exit)).toBe(true)
+        expect(files.exists(workflowPath)).toBe(false)
+        expect(prompter.logs).toContainEqual({
+          level: "warning",
+          message: expect.stringMatching(
+            /Could not set up the GitHub Actions workflow\. Failed to write `.*adamantite\.yml`\./
+          ),
+        })
+        expect(prompter.logs).toContainEqual({
+          level: "warning",
+          message:
+            "Fix the reported problem and run `adamantite init` again, or create the workflow manually.",
+        })
+        expect(prompter.logs).toContainEqual({
+          level: "success",
+          message: "Your project is now configured",
+        })
+        expect(prompter.outros).toEqual(["💠 Adamantite initialized successfully!"])
+      })
+    )
+
     it.effect("skip tsconfig setup when the user declines the TypeScript preset prompt", () =>
       Effect.gen(function* () {
         const files = createInitTestContext()

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -40,7 +40,7 @@ export default Command.make("doctor", { fix }).pipe(
           "`adamantite` is not installed in this project. Install it before running `adamantite doctor`."
         )
         yield* prompter.outro("⚠️ Doctor found issues.")
-        yield* new CommandFailed({
+        return yield* new CommandFailed({
           command: "doctor",
           exitCode: ChildProcessSpawner.ExitCode(1),
         })

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -46,8 +46,8 @@ export default Command.make("doctor", { fix }).pipe(
         })
       }
 
-      // 1. Assess integrations.
-      const assessments = yield* collectApplicableAssessments(integrations, cwd)
+      // 1. Assess integrations, reusing the manifest parsed above.
+      const assessments = yield* collectApplicableAssessments(integrations, cwd, packageJson)
 
       // 2. Print warnings.
       for (const { assessment } of assessments) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -339,7 +339,21 @@ const setupGitHubActions = (
           `GitHub Actions workflow ${created ? "created" : "updated"} successfully.`,
       }
     )
-  }).pipe(Effect.option)
+  }).pipe(
+    // GitHub Actions setup is optional, so initialization continues; the failure must still
+    // reach the user instead of disappearing.
+    Effect.catch((error) =>
+      Effect.gen(function* () {
+        const prompter = yield* Prompter
+        yield* prompter.log.warning(
+          `Could not set up the GitHub Actions workflow. ${error.message}`
+        )
+        yield* prompter.log.warning(
+          "Fix the reported problem and run `adamantite init` again, or create the workflow manually."
+        )
+      })
+    )
+  )
 
 const setupAgentsGuidance = (cwd: string, packageManager: PackageManagerName, scripts: Script[]) =>
   Effect.gen(function* () {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -341,17 +341,26 @@ const setupGitHubActions = (
     )
   }).pipe(
     // GitHub Actions setup is optional, so initialization continues; the failure must still
-    // reach the user instead of disappearing.
-    Effect.catch((error) =>
-      Effect.gen(function* () {
-        const prompter = yield* Prompter
-        yield* prompter.log.warning(
-          `Could not set up the GitHub Actions workflow. ${error.message}`
-        )
-        yield* prompter.log.warning(
-          "Fix the reported problem and run `adamantite init` again, or create the workflow manually."
-        )
-      })
+    // reach the user instead of disappearing. Named tags keep a future error type from
+    // degrading to a warning without an explicit decision.
+    Effect.catchTag(
+      [
+        "FailedToCreateDirectory",
+        "FailedToParseFile",
+        "FailedToReadFile",
+        "FailedToWriteFile",
+        "PlatformError",
+      ],
+      (error) =>
+        Effect.gen(function* () {
+          const prompter = yield* Prompter
+          yield* prompter.log.warning(
+            `Could not set up the GitHub Actions workflow. ${error.message}`
+          )
+          yield* prompter.log.warning(
+            "Fix the reported problem and run `adamantite init` again, or create the workflow manually."
+          )
+        })
     )
   )
 

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -68,7 +68,8 @@ export default Command.make("update").pipe(
 
       yield* prompter.intro("💠 adamantite update")
 
-      const collectAssessments = () => collectApplicableAssessments(integrations, cwd)
+      const collectAssessments = (packageJson?: PackageJson) =>
+        collectApplicableAssessments(integrations, cwd, packageJson)
 
       const assessments = yield* collectAssessments()
 
@@ -122,7 +123,7 @@ export default Command.make("update").pipe(
       }
 
       const packageJson = yield* readPackageJson(cwd)
-      const postMigrationAssessments = yield* collectAssessments()
+      const postMigrationAssessments = yield* collectAssessments(packageJson)
       const postMigrationActions = postMigrationAssessments.flatMap(
         ({ assessment }) => assessment.actions
       )

--- a/src/lib/execution/command-runner.ts
+++ b/src/lib/execution/command-runner.ts
@@ -30,21 +30,30 @@ export class CommandRunner extends Context.Service<
   }
 >()("CommandRunner") {
   static readonly layer = Layer.succeed(this)({
-    run: ({ args, command, cwd, stderr = "inherit", stdin = "ignore", stdout = "inherit" }) =>
-      Effect.mapError(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const handle = yield* ChildProcess.make(command, args, {
-              cwd,
-              stderr,
-              stdin,
-              stdout,
-            })
-
-            return yield* handle.exitCode
+    run: Effect.fn("CommandRunner.run")(function* ({
+      args,
+      command,
+      cwd,
+      stderr = "inherit",
+      stdin = "ignore",
+      stdout = "inherit",
+    }: CommandRunOptions) {
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* ChildProcess.make(command, args, {
+            cwd,
+            stderr,
+            stdin,
+            stdout,
           })
-        ),
-        (cause) => (cause.reason._tag === "NotFound" ? new CliNotFound({ command }) : cause)
-      ),
+
+          return yield* handle.exitCode
+        })
+      ).pipe(
+        Effect.mapError((cause) =>
+          cause.reason._tag === "NotFound" ? new CliNotFound({ command }) : cause
+        )
+      )
+    }),
   })
 }

--- a/src/lib/integrations/base.ts
+++ b/src/lib/integrations/base.ts
@@ -1,4 +1,5 @@
 import type * as Effect from "effect/Effect"
+import type { PackageJson } from "type-fest"
 
 export type IntegrationKind = "tooling" | "workspace" | "editor" | "ci"
 
@@ -67,9 +68,13 @@ export interface AssessableIntegration<Error = unknown, Requirements = unknown> 
    * Read-only diagnosis for the current project state.
    *
    * `assess` may classify package drift, missing config, supported config updates, manual follow-up
-   * work, and known migrations. It must not mutate files or call migrations.
+   * work, and known migrations. It must not mutate files or call migrations. The caller reads
+   * `package.json` once and shares the parsed manifest with every assessment in the same pass.
    */
-  readonly assess: (cwd: string) => Effect.Effect<IntegrationAssessment, Error, Requirements>
+  readonly assess: (
+    cwd: string,
+    packageJson: PackageJson
+  ) => Effect.Effect<IntegrationAssessment, Error, Requirements>
 }
 
 export function defineIntegration<const T extends IntegrationBase<IntegrationKind>>(

--- a/src/lib/integrations/ci/github.ts
+++ b/src/lib/integrations/ci/github.ts
@@ -3,8 +3,7 @@ import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import type { Script, SupportedPackageManager } from "#lib/workspace/package-json.ts"
 import { defineIntegration } from "#lib/integrations/base.ts"
-import { FailedToWriteFile } from "#lib/shared/errors.ts"
-import { ensureDirectory } from "#lib/shared/filesystem.ts"
+import { ensureDirectory, writeFile } from "#lib/shared/filesystem.ts"
 import { getCIWorkflowEntries } from "#lib/workspace/ci-scripts.ts"
 import {
   type NodeVersionSource,
@@ -130,7 +129,6 @@ const files = [{ path: ".github/workflows/adamantite.yml", type: "ci" }] as cons
 
 const writeWorkflow = (cwd: string, options: WorkflowOptions) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
     const resolver = yield* NodeVersionResolver
     const workflowPath = path.join(cwd, files[0].path)
@@ -142,9 +140,7 @@ const writeWorkflow = (cwd: string, options: WorkflowOptions) =>
       return
     }
 
-    yield* fs
-      .writeFileString(workflowPath, workflowContent)
-      .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: workflowPath })))
+    yield* writeFile(workflowPath, workflowContent)
   })
 
 export default defineIntegration({

--- a/src/lib/integrations/editors/vscode.ts
+++ b/src/lib/integrations/editors/vscode.ts
@@ -8,12 +8,10 @@ import { type CommandFailedLike, CommandRunner } from "#lib/execution/command-ru
 import { defineIntegration } from "#lib/integrations/base.ts"
 import {
   FailedToInstallExtension,
-  FailedToReadFile,
-  FailedToWriteFile,
   InvalidConfigFormat,
   VscodeCliNotFound,
 } from "#lib/shared/errors.ts"
-import { ensureDirectory } from "#lib/shared/filesystem.ts"
+import { ensureDirectory, readFile, writeJsonFile } from "#lib/shared/filesystem.ts"
 import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: ".vscode/settings.json", type: "config" }] as const
@@ -55,15 +53,11 @@ export default defineIntegration({
   config: files[0].path,
   create: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
       const settingsPath = path.join(cwd, files[0].path)
 
       yield* ensureDirectory(path.dirname(settingsPath))
-
-      yield* fs
-        .writeFileString(settingsPath, `${JSON.stringify(CONFIG, null, 2)}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: settingsPath })))
+      yield* writeJsonFile(settingsPath, CONFIG)
     }),
   detect: (cwd: string) =>
     Effect.gen(function* () {
@@ -108,14 +102,10 @@ export default defineIntegration({
   name: "vscode",
   update: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
       const settingsPath = path.join(cwd, files[0].path)
 
-      const vscodeFile = yield* fs
-        .readFileString(settingsPath)
-        .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: settingsPath })))
-
+      const vscodeFile = yield* readFile(settingsPath)
       const existingConfig = yield* parseJson(vscodeFile, settingsPath)
 
       if (!Predicate.isObject(existingConfig)) {
@@ -124,8 +114,6 @@ export default defineIntegration({
 
       const newConfig = yield* mergeConfig(CONFIG, existingConfig)
 
-      yield* fs
-        .writeFileString(settingsPath, `${JSON.stringify(newConfig, null, 2)}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: settingsPath })))
+      yield* writeJsonFile(settingsPath, newConfig)
     }),
 })

--- a/src/lib/integrations/editors/zed.ts
+++ b/src/lib/integrations/editors/zed.ts
@@ -5,8 +5,8 @@ import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import * as Schema from "effect/Schema"
 import { defineIntegration } from "#lib/integrations/base.ts"
-import { FailedToReadFile, FailedToWriteFile, InvalidConfigFormat } from "#lib/shared/errors.ts"
-import { ensureDirectory } from "#lib/shared/filesystem.ts"
+import { InvalidConfigFormat } from "#lib/shared/errors.ts"
+import { ensureDirectory, readFile, writeJsonFile } from "#lib/shared/filesystem.ts"
 import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: ".zed/settings.json", type: "config" }] as const
@@ -92,15 +92,11 @@ export default defineIntegration({
   config: files[0].path,
   create: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
       const settingsPath = path.join(cwd, files[0].path)
 
       yield* ensureDirectory(path.dirname(settingsPath))
-
-      yield* fs
-        .writeFileString(settingsPath, `${JSON.stringify(CONFIG, null, 2)}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: settingsPath })))
+      yield* writeJsonFile(settingsPath, CONFIG)
     }),
   detect: (cwd: string) =>
     Effect.gen(function* () {
@@ -113,14 +109,10 @@ export default defineIntegration({
   name: "zed",
   update: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
       const settingsPath = path.join(cwd, files[0].path)
 
-      const zedFile = yield* fs
-        .readFileString(settingsPath)
-        .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: settingsPath })))
-
+      const zedFile = yield* readFile(settingsPath)
       const existingConfig = yield* parseJson(zedFile, settingsPath)
 
       if (!Predicate.isObject(existingConfig)) {
@@ -130,8 +122,6 @@ export default defineIntegration({
       const mergedConfig = yield* mergeConfig(CONFIG, existingConfig)
       const newConfig = deduplicateManagedFormatters(mergedConfig)
 
-      yield* fs
-        .writeFileString(settingsPath, `${JSON.stringify(newConfig, null, 2)}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: settingsPath })))
+      yield* writeJsonFile(settingsPath, newConfig)
     }),
 })

--- a/src/lib/integrations/tooling/__tests__/knip.test.ts
+++ b/src/lib/integrations/tooling/__tests__/knip.test.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import knip from "#lib/integrations/tooling/knip.ts"
+import { readPackageJson } from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -14,6 +15,13 @@ function makeFiles(files?: Record<string, string>) {
 
 function provideFiles(files: FileSystemTestContext) {
   return Effect.provide(Layer.mergeAll(files.layer, Path.layer))
+}
+
+function runAssess(files: FileSystemTestContext) {
+  return readPackageJson(ROOT).pipe(
+    Effect.flatMap((packageJson) => knip.assess(ROOT, packageJson)),
+    provideFiles(files)
+  )
 }
 
 describe("knip", () => {
@@ -88,7 +96,7 @@ describe("knip", () => {
           ),
         })
 
-        const result = yield* knip.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           applicable: false,
@@ -116,7 +124,7 @@ describe("knip", () => {
           ),
         })
 
-        const result = yield* knip.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [
@@ -152,7 +160,7 @@ describe("knip", () => {
           ),
         })
 
-        const result = yield* knip.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [
@@ -189,7 +197,7 @@ describe("knip", () => {
           ),
         })
 
-        const result = yield* knip.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [],

--- a/src/lib/integrations/tooling/__tests__/oxfmt.test.ts
+++ b/src/lib/integrations/tooling/__tests__/oxfmt.test.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import oxfmt from "#lib/integrations/tooling/oxfmt.ts"
+import { readPackageJson } from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -14,6 +15,13 @@ function makeFiles(files?: Record<string, string>) {
 
 function provideFiles(files: FileSystemTestContext) {
   return Effect.provide(Layer.mergeAll(files.layer, Path.layer))
+}
+
+function runAssess(files: FileSystemTestContext) {
+  return readPackageJson(ROOT).pipe(
+    Effect.flatMap((packageJson) => oxfmt.assess(ROOT, packageJson)),
+    provideFiles(files)
+  )
 }
 
 describe("oxfmt", () => {
@@ -88,7 +96,7 @@ describe("oxfmt", () => {
           ),
         })
 
-        const result = yield* oxfmt.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           applicable: false,
@@ -116,7 +124,7 @@ describe("oxfmt", () => {
           ),
         })
 
-        const result = yield* oxfmt.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [
@@ -153,7 +161,7 @@ describe("oxfmt", () => {
           ),
         })
 
-        const result = yield* oxfmt.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [],
@@ -179,7 +187,7 @@ describe("oxfmt", () => {
           ),
         })
 
-        const result = yield* oxfmt.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [

--- a/src/lib/integrations/tooling/__tests__/oxlint.test.ts
+++ b/src/lib/integrations/tooling/__tests__/oxlint.test.ts
@@ -7,6 +7,7 @@ import * as Result from "effect/Result"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import oxlint from "#lib/integrations/tooling/oxlint.ts"
 import tsgolint from "#lib/integrations/tooling/tsgolint.ts"
+import { readPackageJson } from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -16,6 +17,13 @@ function makeFiles(files?: Record<string, string>) {
 
 function provideFiles(files: FileSystemTestContext) {
   return Effect.provide(Layer.mergeAll(files.layer, Path.layer))
+}
+
+function runAssess(integration: typeof oxlint | typeof tsgolint, files: FileSystemTestContext) {
+  return readPackageJson(ROOT).pipe(
+    Effect.flatMap((packageJson) => integration.assess(ROOT, packageJson)),
+    provideFiles(files)
+  )
 }
 
 describe("oxlint", () => {
@@ -200,7 +208,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           applicable: false,
@@ -228,7 +236,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           actions: [
@@ -264,7 +272,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           actions: [
@@ -309,7 +317,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           actions: [],
@@ -347,7 +355,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           actions: [
@@ -390,7 +398,7 @@ describe("oxlint", () => {
           ),
         })
 
-        const result = yield* oxlint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(oxlint, files)
 
         expect(result).toEqual({
           actions: [
@@ -427,7 +435,7 @@ describe("tsgolint", () => {
           ),
         })
 
-        const result = yield* tsgolint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(tsgolint, files)
 
         expect(result).toEqual({
           applicable: false,
@@ -452,7 +460,7 @@ describe("tsgolint", () => {
           ),
         })
 
-        const result = yield* tsgolint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(tsgolint, files)
 
         expect(result).toEqual({
           actions: [
@@ -488,7 +496,7 @@ describe("tsgolint", () => {
           ),
         })
 
-        const result = yield* tsgolint.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(tsgolint, files)
 
         expect(result).toEqual({
           actions: [],

--- a/src/lib/integrations/tooling/__tests__/sherif.test.ts
+++ b/src/lib/integrations/tooling/__tests__/sherif.test.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import sherif from "#lib/integrations/tooling/sherif.ts"
+import { readPackageJson } from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -13,6 +14,13 @@ function makeFiles(files?: Record<string, string>) {
 
 function provideFiles(files: FileSystemTestContext) {
   return Effect.provide(Layer.mergeAll(files.layer, Path.layer))
+}
+
+function runAssess(files: FileSystemTestContext) {
+  return readPackageJson(ROOT).pipe(
+    Effect.flatMap((packageJson) => sherif.assess(ROOT, packageJson)),
+    provideFiles(files)
+  )
 }
 
 describe("sherif", () => {
@@ -33,7 +41,7 @@ describe("sherif", () => {
           ),
         })
 
-        const result = yield* sherif.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           applicable: false,
@@ -58,7 +66,7 @@ describe("sherif", () => {
           ),
         })
 
-        const result = yield* sherif.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [
@@ -94,7 +102,7 @@ describe("sherif", () => {
           ),
         })
 
-        const result = yield* sherif.assess(ROOT).pipe(provideFiles(files))
+        const result = yield* runAssess(files)
 
         expect(result).toEqual({
           actions: [],

--- a/src/lib/integrations/tooling/oxlint.ts
+++ b/src/lib/integrations/tooling/oxlint.ts
@@ -1,15 +1,12 @@
+import type { PackageJson } from "type-fest"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import { defineIntegration, type IntegrationAssessment } from "#lib/integrations/base.ts"
-import {
-  FailedToReadFile,
-  FailedToWriteFile,
-  FileNotFound,
-  UnsupportedConfigState,
-} from "#lib/shared/errors.ts"
+import { FileNotFound, UnsupportedConfigState } from "#lib/shared/errors.ts"
+import { readFile, writeFile } from "#lib/shared/filesystem.ts"
 import { getDependencyVersion } from "#lib/shared/version.macro.ts" with { type: "macro" }
-import { getManagedScripts, readPackageJson } from "#lib/workspace/package-json.ts"
+import { getManagedScripts } from "#lib/workspace/package-json.ts"
 import {
   detectToolingConfig,
   getConfigActions,
@@ -36,10 +33,8 @@ const VERSION = getDependencyVersion("oxlint")
 const detect = (cwd: string) => detectToolingConfig(cwd, "oxlint", configFiles)
 
 export default defineIntegration({
-  assess: (cwd: string) =>
+  assess: (cwd: string, packageJson: PackageJson) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
-      const packageJson = yield* readPackageJson(cwd)
       const managedScripts = getManagedScripts(packageJson)
 
       if (!managedScripts.includes("check") && !managedScripts.includes("fix")) {
@@ -66,11 +61,7 @@ export default defineIntegration({
       const activeConfig = state.active
 
       if (activeConfig?.format === "ts") {
-        const content = yield* fs
-          .readFileString(activeConfig.path)
-          .pipe(
-            Effect.mapError((cause) => new FailedToReadFile({ cause, path: activeConfig.path }))
-          )
+        const content = yield* readFile(activeConfig.path)
         const patch = inspectRequiredOxlintConfig(content)
 
         if (patch.kind === "patchable") {
@@ -100,14 +91,10 @@ export default defineIntegration({
   config: CONFIG_FILE,
   create: (cwd: string, presets: string[] = []) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
-      const configPath = path.join(cwd, CONFIG_FILE)
       const payload = toOxlintTsConfigContent({}, getOxlintPresetNames(presets))
 
-      yield* fs
-        .writeFileString(configPath, payload)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+      yield* writeFile(path.join(cwd, CONFIG_FILE), payload)
     }),
   detect,
   files,
@@ -123,9 +110,7 @@ export default defineIntegration({
         return yield* new FileNotFound({ path: CONFIG_FILE })
       }
 
-      const content = yield* fs
-        .readFileString(configPath)
-        .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: configPath })))
+      const content = yield* readFile(configPath)
       const patch = inspectRequiredOxlintConfig(content)
 
       if (patch.kind === "configured") {
@@ -136,9 +121,7 @@ export default defineIntegration({
         return yield* new UnsupportedConfigState({ path: CONFIG_FILE, reason: patch.reason })
       }
 
-      yield* fs
-        .writeFileString(configPath, patch.updatedContent)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+      yield* writeFile(configPath, patch.updatedContent)
     }),
   version: VERSION,
 })

--- a/src/lib/migrations/base.ts
+++ b/src/lib/migrations/base.ts
@@ -1,6 +1,7 @@
+import type * as FileSystem from "effect/FileSystem"
 import type * as PlatformError from "effect/PlatformError"
 import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import type {
   FailedToDeleteFile,
@@ -16,6 +17,7 @@ import type {
 } from "#lib/shared/errors.ts"
 import type { DependencyInstaller } from "#lib/workspace/dependency-installer.ts"
 import type { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
+import { readFileIfExists, removeFile, writeFile } from "#lib/shared/filesystem.ts"
 
 export interface MigrationContext {
   readonly cwd: string
@@ -82,45 +84,31 @@ export function defineMigration<const T extends Migration>(migration: T): T {
   return migration
 }
 
-export function runMigration(migration: Migration, context: MigrationContext) {
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    const path = yield* Path.Path
-    const filePaths = migration.files ?? []
-    const snapshot = new Map<string, string | null>()
-
-    for (const relativePath of filePaths) {
+export const runMigration = Effect.fn("runMigration")(function* (
+  migration: Migration,
+  context: MigrationContext
+) {
+  const path = yield* Path.Path
+  const filePaths = migration.files ?? []
+  const snapshot = yield* Effect.forEach(
+    filePaths,
+    (relativePath) => {
       const fullPath = path.join(context.cwd, relativePath)
-      const exists = yield* fs.exists(fullPath)
+      return readFileIfExists(fullPath).pipe(Effect.map((content) => [fullPath, content] as const))
+    },
+    { concurrency: "unbounded" }
+  )
 
-      if (exists) {
-        const content = yield* fs.readFileString(fullPath)
-        snapshot.set(fullPath, content)
-      } else {
-        snapshot.set(fullPath, null)
-      }
-    }
-
-    return yield* migration.migrate(context).pipe(
-      Effect.tap(() => migration.validate?.(context) ?? Effect.void),
-      Effect.onError(() =>
-        Effect.gen(function* () {
-          for (const [fullPath, content] of snapshot) {
-            if (content !== null) {
-              yield* fs.writeFileString(fullPath, content).pipe(Effect.ignore)
-              continue
-            }
-
-            const exists = yield* fs.exists(fullPath).pipe(Effect.orElseSucceed(() => false))
-
-            if (!exists) {
-              continue
-            }
-
-            yield* fs.remove(fullPath).pipe(Effect.ignore)
-          }
+  return yield* migration.migrate(context).pipe(
+    Effect.tap(() => migration.validate?.(context) ?? Effect.void),
+    // Restore sequentially and absorb restore failures: the migration error must stay visible.
+    Effect.onError(() =>
+      Effect.forEach(([fullPath, content]: readonly [string, Option.Option<string>]) =>
+        Option.match(content, {
+          onNone: () => removeFile(fullPath).pipe(Effect.ignore),
+          onSome: (value) => writeFile(fullPath, value).pipe(Effect.ignore),
         })
-      )
+      )(snapshot)
     )
-  })
-}
+  )
+})

--- a/src/lib/migrations/hardcoded-node-version.ts
+++ b/src/lib/migrations/hardcoded-node-version.ts
@@ -1,9 +1,10 @@
 import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import github from "#lib/integrations/ci/github.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
-import { FailedToReadFile, MigrationValidationFailed } from "#lib/shared/errors.ts"
+import { MigrationValidationFailed } from "#lib/shared/errors.ts"
+import { readFileIfExists } from "#lib/shared/filesystem.ts"
 import { hasCICompatibleScripts } from "#lib/workspace/ci-scripts.ts"
 import { DependencyInstaller } from "#lib/workspace/dependency-installer.ts"
 import {
@@ -20,18 +21,8 @@ function getGitHubWorkflowPath() {
 
 const readWorkflow = (cwd: string) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
-    const workflowPath = path.join(cwd, getGitHubWorkflowPath())
-    const exists = yield* fs.exists(workflowPath)
-
-    if (!exists) {
-      return null
-    }
-
-    return yield* fs
-      .readFileString(workflowPath)
-      .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: workflowPath })))
+    return yield* readFileIfExists(path.join(cwd, getGitHubWorkflowPath()))
   })
 
 const canRegenerateWorkflow = (cwd: string) =>
@@ -70,7 +61,7 @@ export default defineMigration({
     Effect.gen(function* () {
       const workflow = yield* readWorkflow(context.cwd)
 
-      if (workflow === null || !HARDCODED_NODE_VERSION_REGEX.test(workflow)) {
+      if (!Option.exists(workflow, (content) => HARDCODED_NODE_VERSION_REGEX.test(content))) {
         return { status: "not-applicable", warnings: [] } as const
       }
 
@@ -117,7 +108,7 @@ export default defineMigration({
     Effect.gen(function* () {
       const workflow = yield* readWorkflow(context.cwd)
 
-      if (workflow !== null && HARDCODED_NODE_VERSION_REGEX.test(workflow)) {
+      if (Option.exists(workflow, (content) => HARDCODED_NODE_VERSION_REGEX.test(content))) {
         return yield* new MigrationValidationFailed({
           migrationId: "hardcoded-node-version",
           reason: "The GitHub Actions workflow still contains a hard-coded Node.js version.",

--- a/src/lib/migrations/legacy-json-config.ts
+++ b/src/lib/migrations/legacy-json-config.ts
@@ -1,17 +1,12 @@
+import type * as FileSystem from "effect/FileSystem"
 import type * as PlatformError from "effect/PlatformError"
 import type { JsonObject } from "type-fest"
 import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import type { ToolingConfigState } from "#lib/workspace/tooling/config.ts"
 import { defineMigration } from "#lib/migrations/base.ts"
-import {
-  FailedToDeleteFile,
-  FailedToReadFile,
-  FailedToWriteFile,
-  InvalidConfigFormat,
-  MigrationValidationFailed,
-} from "#lib/shared/errors.ts"
+import { InvalidConfigFormat, MigrationValidationFailed } from "#lib/shared/errors.ts"
+import { readFile, removeFile, writeFile } from "#lib/shared/filesystem.ts"
 import { checkIsJsonObject, parseJson } from "#lib/shared/json.ts"
 
 interface LegacyJsonConfigIntegration {
@@ -42,7 +37,6 @@ export interface LegacyJsonConfigMigrationOptions {
 
 function migrateLegacyJsonConfig(cwd: string, options: LegacyJsonConfigMigrationOptions) {
   return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
     const state = yield* options.integration.detect(cwd)
 
@@ -54,10 +48,7 @@ function migrateLegacyJsonConfig(cwd: string, options: LegacyJsonConfigMigration
 
     const legacyConfigPath = state.active.path
     const configPath = path.join(cwd, options.integration.config)
-    const legacyConfigContent = yield* fs
-      .readFileString(legacyConfigPath)
-      .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: legacyConfigPath })))
-
+    const legacyConfigContent = yield* readFile(legacyConfigPath)
     const existingConfig = yield* parseJson(legacyConfigContent, legacyConfigPath)
 
     if (!checkIsJsonObject(existingConfig)) {
@@ -66,16 +57,10 @@ function migrateLegacyJsonConfig(cwd: string, options: LegacyJsonConfigMigration
 
     const { $schema: _schema, ...configWithoutSchema } = existingConfig
 
-    yield* fs
-      .writeFileString(configPath, options.serialize(configWithoutSchema))
-      .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+    yield* writeFile(configPath, options.serialize(configWithoutSchema))
 
     for (const legacyConfig of [state.active, ...state.legacy]) {
-      yield* fs
-        .remove(legacyConfig.path)
-        .pipe(
-          Effect.mapError((cause) => new FailedToDeleteFile({ cause, path: legacyConfig.path }))
-        )
+      yield* removeFile(legacyConfig.path)
     }
 
     return { warnings: [] }

--- a/src/lib/shared/assessment.ts
+++ b/src/lib/shared/assessment.ts
@@ -1,5 +1,6 @@
 import type * as FileSystem from "effect/FileSystem"
 import type * as Path from "effect/Path"
+import type { PackageJson } from "type-fest"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
@@ -23,9 +24,10 @@ type AnyAssessableIntegration = IntegrationBase<IntegrationKind> & AssessableInt
 
 const collect = Effect.fn("collectApplicableAssessments")(function* (
   integrations: readonly AnyAssessableIntegration[],
-  cwd: string
+  cwd: string,
+  manifest?: PackageJson
 ) {
-  const packageJson = yield* readPackageJson(cwd)
+  const packageJson = manifest ?? (yield* readPackageJson(cwd))
 
   return yield* Effect.forEach(
     integrations,
@@ -46,7 +48,8 @@ const collect = Effect.fn("collectApplicableAssessments")(function* (
 
 export function collectApplicableAssessments<const I extends AnyAssessableIntegration>(
   integrations: readonly I[],
-  cwd: string
+  cwd: string,
+  packageJson?: PackageJson
 ): Effect.Effect<
   Array<AssessedIntegration<I>>,
   Effect.Error<ReturnType<I["assess"]>> | FailedToParseFile | FailedToReadFile,
@@ -54,7 +57,8 @@ export function collectApplicableAssessments<const I extends AnyAssessableIntegr
 >
 export function collectApplicableAssessments(
   integrations: readonly AnyAssessableIntegration[],
-  cwd: string
+  cwd: string,
+  packageJson?: PackageJson
 ) {
-  return collect(integrations, cwd)
+  return collect(integrations, cwd, packageJson)
 }

--- a/src/lib/shared/assessment.ts
+++ b/src/lib/shared/assessment.ts
@@ -1,3 +1,5 @@
+import type * as FileSystem from "effect/FileSystem"
+import type * as Path from "effect/Path"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
@@ -7,6 +9,8 @@ import type {
   IntegrationKind,
   IntegrationAssessment,
 } from "#lib/integrations/base.ts"
+import type { FailedToParseFile, FailedToReadFile } from "#lib/shared/errors.ts"
+import { readPackageJson } from "#lib/workspace/package-json.ts"
 
 export type ApplicableAssessment = Extract<IntegrationAssessment, { readonly applicable: true }>
 
@@ -17,28 +21,36 @@ export interface AssessedIntegration<I extends IntegrationBase<IntegrationKind>>
 
 type AnyAssessableIntegration = IntegrationBase<IntegrationKind> & AssessableIntegration
 
-const collect = Effect.fn("collectApplicableAssessments")(
-  (integrations: readonly AnyAssessableIntegration[], cwd: string) =>
-    Effect.forEach((integration: AnyAssessableIntegration) =>
+const collect = Effect.fn("collectApplicableAssessments")(function* (
+  integrations: readonly AnyAssessableIntegration[],
+  cwd: string
+) {
+  const packageJson = yield* readPackageJson(cwd)
+
+  return yield* Effect.forEach(
+    integrations,
+    (integration) =>
       integration
-        .assess(cwd)
+        .assess(cwd, packageJson)
         .pipe(
           Effect.map((assessment) =>
             assessment.applicable
               ? Option.some({ assessment, integration })
               : Option.none<AssessedIntegration<AnyAssessableIntegration>>()
           )
-        )
-    )(integrations).pipe(Effect.map((optionalAssessments) => Array.getSomes(optionalAssessments)))
-)
+        ),
+    // Assessments are read-only and independent, and `forEach` keeps results in input order.
+    { concurrency: "unbounded" }
+  ).pipe(Effect.map((optionalAssessments) => Array.getSomes(optionalAssessments)))
+})
 
 export function collectApplicableAssessments<const I extends AnyAssessableIntegration>(
   integrations: readonly I[],
   cwd: string
 ): Effect.Effect<
   Array<AssessedIntegration<I>>,
-  Effect.Error<ReturnType<I["assess"]>>,
-  Effect.Services<ReturnType<I["assess"]>>
+  Effect.Error<ReturnType<I["assess"]>> | FailedToParseFile | FailedToReadFile,
+  Effect.Services<ReturnType<I["assess"]>> | FileSystem.FileSystem | Path.Path
 >
 export function collectApplicableAssessments(
   integrations: readonly AnyAssessableIntegration[],

--- a/src/lib/shared/filesystem.ts
+++ b/src/lib/shared/filesystem.ts
@@ -1,11 +1,58 @@
+import type * as Schema from "effect/Schema"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
-import { FailedToCreateDirectory } from "#lib/shared/errors.ts"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import {
+  FailedToCreateDirectory,
+  FailedToDeleteFile,
+  FailedToReadFile,
+  FailedToWriteFile,
+} from "#lib/shared/errors.ts"
 
 export const ensureDirectory = (path: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-    yield* fs
-      .makeDirectory(path, { recursive: true })
-      .pipe(Effect.mapError((cause) => new FailedToCreateDirectory({ cause, path })))
-  })
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.makeDirectory(path, { recursive: true })),
+    Effect.mapError((cause) => new FailedToCreateDirectory({ cause, path }))
+  )
+
+export const readFile = (path: string) =>
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.readFileString(path)),
+    Effect.mapError((cause) => new FailedToReadFile({ cause, path }))
+  )
+
+/**
+ * Reads a file that may not exist. A missing file is `Option.none`; every other failure is a
+ * `FailedToReadFile`. Reading directly instead of checking `exists` first keeps the operation
+ * atomic.
+ */
+export const readFileIfExists = (path: string) =>
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.readFileString(path)),
+    Effect.map((content) => pipe(content, Option.some)),
+    Effect.catch((error) =>
+      error.reason._tag === "NotFound"
+        ? Effect.succeedNone
+        : Effect.fail(new FailedToReadFile({ cause: error, path }))
+    )
+  )
+
+export const writeFile = (path: string, content: string) =>
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.writeFileString(path, content)),
+    Effect.mapError((cause) => new FailedToWriteFile({ cause, path }))
+  )
+
+/**
+ * Writes a value as two-space-indented JSON with a trailing newline, the format every
+ * Adamantite-managed JSON file uses.
+ */
+export const writeJsonFile = (path: string, value: Schema.Json) =>
+  writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+
+export const removeFile = (path: string) =>
+  FileSystem.FileSystem.pipe(
+    Effect.flatMap((fs) => fs.remove(path)),
+    Effect.mapError((cause) => new FailedToDeleteFile({ cause, path }))
+  )

--- a/src/lib/shared/json.ts
+++ b/src/lib/shared/json.ts
@@ -9,18 +9,15 @@ import { type ParseError, parse } from "jsonc-parser"
 import { FailedToMergeConfig, FailedToParseFile } from "#lib/shared/errors.ts"
 
 export const parseJson = (content: string, path?: string) =>
-  Effect.sync(() => {
+  Effect.suspend(() => {
     const errors: ParseError[] = []
     // SAFETY: jsonc-parser returns plain JSON data; parse failures surface through `errors`.
     const parsed = parse(content, errors, { allowTrailingComma: true }) as JsonValue
-    return { errors, parsed }
-  }).pipe(
-    Effect.flatMap(({ errors, parsed }) =>
-      errors.length > 0
-        ? Effect.fail(new FailedToParseFile({ errors, path }))
-        : Effect.succeed(parsed)
-    )
-  )
+
+    return errors.length > 0
+      ? Effect.fail(new FailedToParseFile({ errors, path }))
+      : Effect.succeed(parsed)
+  })
 
 export const checkIsJsonObject = (value: JsonValue): value is JsonObject =>
   Predicate.isObject(value)

--- a/src/lib/workspace/__tests__/agents.test.ts
+++ b/src/lib/workspace/__tests__/agents.test.ts
@@ -56,17 +56,17 @@ describe("writeAgentsGuidance", () => {
     })
   )
 
-  it.effect("return FailedToReadFile when checking whether AGENTS.md exists fails", () =>
+  it.effect("return FailedToReadFile when reading AGENTS.md fails", () =>
     Effect.gen(function* () {
       const agentsPath = `${ROOT}/AGENTS.md`
       const cause = PlatformError.systemError({
         _tag: "PermissionDenied",
-        method: "access",
+        method: "readFileString",
         module: "FileSystem",
         pathOrDescriptor: agentsPath,
       })
       const fileSystemLayer = FileSystem.layerNoop({
-        exists: () => Effect.fail(cause),
+        readFileString: () => Effect.fail(cause),
       })
 
       const result = yield* writeAgentsGuidance(ROOT, {

--- a/src/lib/workspace/agents.ts
+++ b/src/lib/workspace/agents.ts
@@ -1,11 +1,10 @@
 import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
 import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import * as String from "effect/String"
 import { runScriptCommand, type PackageManagerName } from "nypm"
-import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
+import { readFileIfExists, writeFile } from "#lib/shared/filesystem.ts"
 import { MANAGED_SCRIPT_COMMANDS, type Script } from "#lib/workspace/package-json.ts"
 
 const AGENTS_NAME = "AGENTS.md"
@@ -71,17 +70,12 @@ function getAgentsSection({ packageManager, scripts }: WriteAgentsGuidanceOption
 
 export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOptions) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
     const agentsPath = path.join(cwd, AGENTS_NAME)
-    const exists = yield* fs
-      .exists(agentsPath)
-      .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: agentsPath })))
-    const existing = exists
-      ? yield* fs
-          .readFileString(agentsPath)
-          .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: agentsPath })))
-      : ""
+    const existing = pipe(
+      yield* readFileIfExists(agentsPath),
+      Option.getOrElse(() => "")
+    )
     const startIndex = pipe(existing, String.indexOf(ADAMANTITE_AGENTS_START_MARKER))
     const endIndex = pipe(existing, String.indexOf(ADAMANTITE_AGENTS_END_MARKER))
     const markerRange = pipe(
@@ -95,9 +89,7 @@ export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOpt
       const sectionEnd = end + ADAMANTITE_AGENTS_END_MARKER.length
       const nextContent = `${existing.slice(0, start)}${section.trimEnd()}${existing.slice(sectionEnd)}`
 
-      yield* fs
-        .writeFileString(agentsPath, nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: agentsPath })))
+      yield* writeFile(agentsPath, nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`)
 
       return "updated" as const
     }
@@ -114,9 +106,7 @@ export const writeAgentsGuidance = (cwd: string, options: WriteAgentsGuidanceOpt
           ? "\n"
           : "\n\n"
 
-    yield* fs
-      .writeFileString(agentsPath, `${existing}${separator}${section}`)
-      .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: agentsPath })))
+    yield* writeFile(agentsPath, `${existing}${separator}${section}`)
 
     return "updated" as const
   })

--- a/src/lib/workspace/dependency-installer.ts
+++ b/src/lib/workspace/dependency-installer.ts
@@ -30,15 +30,22 @@ export class DependencyInstaller extends Context.Service<
   }
 >()("DependencyInstaller") {
   static readonly layer = Layer.succeed(this)({
-    addDevDependencies: (packages, cwd, options) =>
-      Effect.tryPromise({
-        catch: (cause) => new FailedToInstallDependency({ cause, packages }),
-        try: () => addDevDependency(packages, { ...options, cwd }),
-      }).pipe(Effect.asVoid),
-    detectPackageManager: (cwd) =>
+    addDevDependencies: Effect.fn("DependencyInstaller.addDevDependencies")(
+      (
+        packages: string[],
+        cwd: string,
+        options?: { readonly silent?: boolean; readonly workspace?: boolean }
+      ) =>
+        Effect.tryPromise({
+          catch: (cause) => new FailedToInstallDependency({ cause, packages }),
+          try: () => addDevDependency(packages, { ...options, cwd }),
+        }).pipe(Effect.asVoid)
+    ),
+    detectPackageManager: Effect.fn("DependencyInstaller.detectPackageManager")((cwd: string) =>
       Effect.tryPromise({
         catch: (cause) => new NoPackageManager({ cause }),
         try: () => detectNypmPackageManager(cwd),
-      }).pipe(Effect.map((detectedPackageManager) => detectedPackageManager ?? null)),
+      }).pipe(Effect.map((detectedPackageManager) => detectedPackageManager ?? null))
+    ),
   })
 }

--- a/src/lib/workspace/node-version-resolver.ts
+++ b/src/lib/workspace/node-version-resolver.ts
@@ -1,14 +1,15 @@
-import type * as PlatformError from "effect/PlatformError"
 import type { JsonValue } from "type-fest"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import * as Schema from "effect/Schema"
 import * as Str from "effect/String"
-import { type FailedToParseFile, FailedToReadFile } from "#lib/shared/errors.ts"
+import type { FailedToParseFile, FailedToReadFile } from "#lib/shared/errors.ts"
+import { readFileIfExists } from "#lib/shared/filesystem.ts"
 import { parseJson } from "#lib/shared/json.ts"
 
 /**
@@ -87,10 +88,7 @@ export class NodeVersionResolver extends Context.Service<
   {
     readonly resolve: (
       cwd: string
-    ) => Effect.Effect<
-      NodeVersionSource,
-      FailedToParseFile | FailedToReadFile | PlatformError.PlatformError
-    >
+    ) => Effect.Effect<NodeVersionSource, FailedToParseFile | FailedToReadFile>
   }
 >()("NodeVersionResolver") {
   static readonly layer = Layer.effect(
@@ -100,39 +98,33 @@ export class NodeVersionResolver extends Context.Service<
       const path = yield* Path.Path
 
       const readDeclarationFile = (cwd: string, file: string) =>
-        Effect.gen(function* () {
-          const filePath = path.join(cwd, file)
-          const exists = yield* fs.exists(filePath)
-
-          if (!exists) {
-            return null
-          }
-
-          return yield* fs
-            .readFileString(filePath)
-            .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: filePath })))
-        })
+        readFileIfExists(path.join(cwd, file)).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs)
+        )
 
       return {
         resolve: Effect.fn("NodeVersionResolver.resolve")(function* (cwd: string) {
           for (const file of VERSION_FILES) {
             const content = yield* readDeclarationFile(cwd, file)
 
-            if (content !== null && Str.isNonEmpty(content.trim())) {
+            if (Option.exists(content, (value) => Str.isNonEmpty(value.trim()))) {
               return fileSource(file)
             }
           }
 
           const toolVersions = yield* readDeclarationFile(cwd, ".tool-versions")
 
-          if (toolVersions !== null && hasToolVersionsNodeEntry(toolVersions)) {
+          if (Option.exists(toolVersions, (content) => hasToolVersionsNodeEntry(content))) {
             return fileSource(".tool-versions")
           }
 
           const packageJsonContent = yield* readDeclarationFile(cwd, "package.json")
 
-          if (packageJsonContent !== null) {
-            const packageJson = yield* parseJson(packageJsonContent, path.join(cwd, "package.json"))
+          if (Option.isSome(packageJsonContent)) {
+            const packageJson = yield* parseJson(
+              packageJsonContent.value,
+              path.join(cwd, "package.json")
+            )
 
             if (hasNodeDeclaration(packageJson)) {
               return fileSource("package.json")

--- a/src/lib/workspace/package-json.ts
+++ b/src/lib/workspace/package-json.ts
@@ -3,12 +3,11 @@ import type { PackageManagerName } from "nypm"
 import type { PackageJson } from "type-fest"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
-import * as FileSystem from "effect/FileSystem"
 import { pipe } from "effect/Function"
 import * as Path from "effect/Path"
 import * as Record from "effect/Record"
 import * as Result from "effect/Result"
-import { FailedToReadFile, FailedToWriteFile } from "#lib/shared/errors.ts"
+import { readFile, writeJsonFile } from "#lib/shared/filesystem.ts"
 import { parseJson } from "#lib/shared/json.ts"
 
 const WORKSPACE_PREFIX_REGEX = /^workspace:/
@@ -20,12 +19,9 @@ export function normalizeDependencyVersion(specifier: string) {
 
 export const readPackageJson = (cwd: string = process.cwd()) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
     const packagePath = path.join(cwd, "package.json")
-    const content = yield* fs
-      .readFileString(packagePath)
-      .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: packagePath })))
+    const content = yield* readFile(packagePath)
     const parsed = yield* parseJson(content, packagePath)
     // SAFETY: the file is the project's package.json; every manifest field is optional in
     // `PackageJson`, so any parsed JSON object satisfies it.
@@ -34,13 +30,8 @@ export const readPackageJson = (cwd: string = process.cwd()) =>
 
 export const writePackageJson = (cwd: string, packageJson: PackageJson) =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
-    const packagePath = path.join(cwd, "package.json")
-
-    yield* fs
-      .writeFileString(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`)
-      .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: packagePath })))
+    yield* writeJsonFile(path.join(cwd, "package.json"), packageJson)
   })
 
 /**

--- a/src/lib/workspace/tooling/config.ts
+++ b/src/lib/workspace/tooling/config.ts
@@ -12,11 +12,10 @@ import {
   type IntegrationFile,
   type ToolingPackage,
 } from "#lib/integrations/base.ts"
-import { FailedToWriteFile } from "#lib/shared/errors.ts"
+import { writeFile } from "#lib/shared/filesystem.ts"
 import {
   getManagedScripts,
   normalizeDependencyVersion,
-  readPackageJson,
   type Script,
 } from "#lib/workspace/package-json.ts"
 
@@ -230,10 +229,8 @@ export function definePackageTooling(options: {
   readonly version: string
 }) {
   return defineIntegration({
-    assess: (cwd: string) =>
-      Effect.gen(function* () {
-        const packageJson = yield* readPackageJson(cwd)
-
+    assess: (_cwd: string, packageJson: PackageJson) =>
+      Effect.sync(() => {
         if (!checkHasManagedScript(packageJson, options.scripts)) {
           return {
             applicable: false,
@@ -275,10 +272,8 @@ export function defineConfigTooling(options: {
   const detect = (cwd: string) => detectToolingConfig(cwd, options.name, options.configFiles)
 
   return defineIntegration({
-    assess: (cwd: string) =>
+    assess: (cwd: string, packageJson: PackageJson) =>
       Effect.gen(function* () {
-        const packageJson = yield* readPackageJson(cwd)
-
         if (!checkHasManagedScript(packageJson, options.scripts)) {
           return {
             applicable: false,
@@ -304,13 +299,8 @@ export function defineConfigTooling(options: {
     config: options.configFiles.config,
     create: (cwd: string) =>
       Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem
         const path = yield* Path.Path
-        const configPath = path.join(cwd, options.configFiles.config)
-
-        yield* fs
-          .writeFileString(configPath, options.configContent())
-          .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+        yield* writeFile(path.join(cwd, options.configFiles.config), options.configContent())
       }),
     detect,
     files,

--- a/src/lib/workspace/tsconfig.ts
+++ b/src/lib/workspace/tsconfig.ts
@@ -5,7 +5,8 @@ import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import { defineIntegration } from "#lib/integrations/base.ts"
-import { FailedToReadFile, FailedToWriteFile, InvalidConfigFormat } from "#lib/shared/errors.ts"
+import { InvalidConfigFormat } from "#lib/shared/errors.ts"
+import { readFile, writeJsonFile } from "#lib/shared/filesystem.ts"
 import { mergeConfig, parseJson } from "#lib/shared/json.ts"
 
 const files = [{ path: "tsconfig.json", type: "config" }] as const
@@ -36,14 +37,8 @@ export default defineIntegration({
   config: files[0].path,
   create: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
-      const configPath = path.join(cwd, files[0].path)
-      const payload = JSON.stringify(CONFIG, null, 2)
-
-      yield* fs
-        .writeFileString(configPath, `${payload}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+      yield* writeJsonFile(path.join(cwd, files[0].path), CONFIG)
     }),
   detect: (cwd: string) =>
     Effect.gen(function* () {
@@ -56,13 +51,10 @@ export default defineIntegration({
   name: "tsconfig",
   update: (cwd: string) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
       const path = yield* Path.Path
       const configPath = path.join(cwd, files[0].path)
 
-      const tsconfigFile = yield* fs
-        .readFileString(configPath)
-        .pipe(Effect.mapError((cause) => new FailedToReadFile({ cause, path: configPath })))
+      const tsconfigFile = yield* readFile(configPath)
       const existingConfig = yield* parseJson(tsconfigFile, configPath)
 
       if (!Predicate.isObject(existingConfig)) {
@@ -75,8 +67,6 @@ export default defineIntegration({
         extends: mergeExtends("extends" in existingConfig ? existingConfig.extends : undefined),
       }
 
-      yield* fs
-        .writeFileString(configPath, `${JSON.stringify(newConfig, null, 2)}\n`)
-        .pipe(Effect.mapError((cause) => new FailedToWriteFile({ cause, path: configPath })))
+      yield* writeJsonFile(configPath, newConfig)
     }),
 })


### PR DESCRIPTION
An audit of our Effect usage (via the effect/effect-ts skills) found a few places where the CLI hid failures or did redundant work. This PR applies the fixes.

The worst offender: `adamantite init` piped its GitHub Actions setup through `Effect.option`, so a failed workflow write vanished entirely — the run still ended with "Adamantite initialized successfully!". Setup failures now surface as warnings with the underlying reason and a recovery hint, matching how the editor-extension and AGENTS.md steps already degrade.

`doctor` and `update` also parsed `package.json` up to eleven times per run (once per integration per assessment pass) and assessed integrations sequentially. Assessments now share a single parsed manifest per pass via `assess(cwd, packageJson)` and run concurrently; each pass still reads fresh, so re-assessment after migrations keeps seeing current state.

Supporting changes:

- `src/lib/shared/filesystem.ts` grew `readFile`/`writeFile`/`writeJsonFile`/`readFileIfExists`/`removeFile` helpers, replacing ~20 hand-rolled `mapError` wrappers and the exists-then-read pattern (`readFileIfExists` treats only `NotFound` as absent, so the check-then-read race is gone).
- `Effect.fn` spans on `CommandRunner.run`, the `DependencyInstaller` methods, `runMigration`, and assessment collection, so failures carry trace context.
- The in-memory test FileSystem now reports `BadResource` when reading a directory path, mirroring the Node backend's `EISDIR` mapping — this keeps the "AGENTS.md is a directory" init test honest under the new direct-read flow.
- `NodeVersionResolver.resolve` no longer leaks raw `PlatformError` in its error union.
- Small cleanups: `parseJson` via `Effect.suspend`, concurrent migration file snapshots, `return yield*` in doctor.

Includes a patch changeset. `pnpm run check`, `test` (353 passing), `format`, and `analyze` are all green.

Changes made with Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)