### PR TITLE
Property-test core invariants with fast-check and pin two serializer bugs

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import type { PackageJson } from "type-fest"
+import type { JsonValue, PackageJson } from "type-fest"
 
 import { describe, expect, it } from "@effect/vitest"
 import * as Console from "effect/Console"
@@ -6,8 +6,10 @@ import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
+import * as Predicate from "effect/Predicate"
 import * as Result from "effect/Result"
 import * as Terminal from "effect/Terminal"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import { mergeConfig, parseJson, serializeTsObjectLiteral } from "#lib/shared/json.ts"
 import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
@@ -16,6 +18,29 @@ import { printTitle } from "#terminal/title.ts"
 
 const ROOT = "/project"
 const noop = () => null
+
+function someKey(value: JsonValue, predicate: (key: string) => boolean): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => someKey(entry, predicate))
+  }
+
+  if (Predicate.isObject(value)) {
+    return Object.entries(value).some(([key, entry]) => predicate(key) || someKey(entry, predicate))
+  }
+
+  return false
+}
+
+// SAFETY: fast-check's JsonValue and type-fest's JsonValue describe the same JSON data shapes.
+const jsonValueArbitrary = FastCheck.jsonValue({ maxDepth: 4 }).map((value) => value as JsonValue)
+
+async function evaluateTsLiteral(serialized: string): Promise<JsonValue> {
+  const uri = `data:text/javascript,export default (${encodeURIComponent(serialized)})`
+  // SAFETY: the module evaluates a serialized JSON value, so its default export is a JsonValue.
+  const module = (await import(/* @vite-ignore */ uri)) as { default: JsonValue }
+
+  return module.default
+}
 
 function makeFiles(files?: Record<string, string>) {
   return createFileSystemTestContext({ files, root: ROOT })
@@ -190,6 +215,42 @@ describe("parseJson", () => {
       }
     })
   )
+
+  it.effect("strip __proto__ keys (jsonc-parser pollution protection)", () =>
+    Effect.gen(function* () {
+      const parsed = yield* parseJson('{"__proto__": {"polluted": true}, "a": 1}')
+
+      expect(parsed).toEqual({ a: 1 })
+    })
+  )
+
+  it.effect.prop(
+    "round-trip any JSON value without __proto__ keys through JSON.stringify",
+    {
+      value: jsonValueArbitrary.filter((value) => !someKey(value, (key) => key === "__proto__")),
+    },
+    ({ value }) =>
+      Effect.gen(function* () {
+        const parsed = yield* parseJson(JSON.stringify(value))
+
+        expect(JSON.stringify(parsed)).toBe(JSON.stringify(value))
+      }),
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  it.effect.prop(
+    "resolve to success or FailedToParseFile for arbitrary input, never a defect",
+    { content: FastCheck.string() },
+    ({ content }) =>
+      Effect.gen(function* () {
+        const result = yield* Effect.result(parseJson(content))
+
+        if (Result.isFailure(result)) {
+          expect(result.failure).toMatchObject({ _tag: "FailedToParseFile" })
+        }
+      }),
+    { fastCheck: { numRuns: 500 } }
+  )
 })
 
 describe("mergeConfig", () => {
@@ -244,6 +305,73 @@ describe("mergeConfig", () => {
         expect(result.failure).toMatchObject({ _tag: "FailedToMergeConfig" })
       }
     })
+  )
+
+  it.effect("drop null-valued keys from the first argument (defu behavior)", () =>
+    Effect.gen(function* () {
+      expect(yield* mergeConfig({ a: null }, {})).toEqual({})
+      expect(yield* mergeConfig({}, { a: null })).toEqual({ a: null })
+    })
+  )
+
+  // defu drops `__proto__`/`constructor` keys and null-valued keys from its first argument, and
+  // concatenates arrays on conflicts, so these algebraic properties hold on array-free, null-free
+  // configs with plain keys.
+  const jsonPrimitive = FastCheck.oneof(
+    FastCheck.string(),
+    FastCheck.integer(),
+    FastCheck.boolean()
+  )
+  const plainKey = FastCheck.string().filter((key) => key !== "__proto__" && key !== "constructor")
+  const arrayFreeConfig = FastCheck.dictionary(
+    plainKey,
+    FastCheck.oneof(jsonPrimitive, FastCheck.dictionary(plainKey, jsonPrimitive, { maxKeys: 4 })),
+    { maxKeys: 8 }
+  )
+
+  it.effect.prop(
+    "treat the empty object as the identity on both sides",
+    { config: arrayFreeConfig },
+    ({ config }) =>
+      Effect.gen(function* () {
+        expect(yield* mergeConfig(config, {})).toEqual(config)
+        expect(yield* mergeConfig({}, config)).toEqual(config)
+      }),
+    { fastCheck: { numRuns: 200 } }
+  )
+
+  it.effect.prop(
+    "merge any config with itself without changing it",
+    { config: arrayFreeConfig },
+    ({ config }) =>
+      Effect.gen(function* () {
+        expect(yield* mergeConfig(config, config)).toEqual(config)
+      }),
+    { fastCheck: { numRuns: 200 } }
+  )
+
+  it.effect.prop(
+    "keep every key from both inputs and prefer the first argument on conflicts",
+    { base: arrayFreeConfig, override: arrayFreeConfig },
+    ({ base, override }) =>
+      Effect.gen(function* () {
+        const merged = yield* mergeConfig(base, override)
+
+        for (const key of [...Object.keys(base), ...Object.keys(override)]) {
+          expect(Object.hasOwn(merged, key)).toBe(true)
+        }
+        for (const [key, value] of Object.entries(base)) {
+          if (!Predicate.isObject(value)) {
+            expect(merged[key]).toBe(value)
+          }
+        }
+        for (const key of Object.keys(override)) {
+          if (!Object.hasOwn(base, key)) {
+            expect(merged[key]).toEqual(override[key])
+          }
+        }
+      }),
+    { fastCheck: { numRuns: 200 } }
   )
 })
 
@@ -309,6 +437,73 @@ describe("serializeTsObjectLiteral", () => {
     }
 }`)
   })
+
+  // Both known bugs come from the key-unquoting regex matching text it should not: the escaped
+  // quote in a serialized key produces a bare `"A":` substring, and `__proto__` is a valid
+  // identifier but means prototype assignment once unquoted.
+  it.fails("known bug: a key containing a double quote produces invalid syntax", async () => {
+    const value = { '"A': null }
+    const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))
+
+    expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
+  })
+
+  it.fails("known bug: an unquoted __proto__ key changes the evaluated object", async () => {
+    // SAFETY: JSON.parse creates `__proto__` as an own property, unlike an object literal.
+    const value = JSON.parse('{"__proto__": {"polluted": true}}') as JsonValue
+    const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))
+
+    expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
+  })
+
+  const hazardFreeJsonValue = jsonValueArbitrary.filter(
+    (value) => !someKey(value, (key) => key.includes('"') || key === "__proto__")
+  )
+
+  it.effect.prop(
+    "evaluate back to the original value for any JSON value without hazardous keys",
+    { value: hazardFreeJsonValue },
+    ({ value }) =>
+      Effect.gen(function* () {
+        const evaluated = yield* Effect.promise(() =>
+          evaluateTsLiteral(serializeTsObjectLiteral(value))
+        )
+
+        expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
+      }),
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  // Focused generator for the risky surface: identifier-like keys next to string values full of
+  // quotes, backslashes, colons, and braces that the key-unquoting regex could corrupt. Escaping
+  // keeps string values safe; only keys containing a double quote break (pinned above).
+  const trickyString = FastCheck.array(
+    FastCheck.constantFrom('"', "\\", ":", "\n", " ", "a", "$", "_", "{", "}", "'", "`"),
+    { maxLength: 12 }
+  ).map((chars) => chars.join(""))
+  const trickyKey = FastCheck.oneof(
+    FastCheck.constantFrom("enabled", "entry", "$schema", "_private", "a1"),
+    trickyString.map((text) => text.replaceAll('"', ""))
+  )
+  const trickyObject = FastCheck.dictionary(
+    trickyKey,
+    FastCheck.oneof(trickyString, FastCheck.dictionary(trickyKey, trickyString, { maxKeys: 3 })),
+    { maxKeys: 6 }
+  )
+
+  it.effect.prop(
+    "never corrupt string values that look like keys, at any indentation",
+    { indentation: FastCheck.constantFrom<number | string>(0, 2, 4, "\t"), value: trickyObject },
+    ({ indentation, value }) =>
+      Effect.gen(function* () {
+        const evaluated = yield* Effect.promise(() =>
+          evaluateTsLiteral(serializeTsObjectLiteral(value, { indentation }))
+        )
+
+        expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
+      }),
+    { fastCheck: { numRuns: 500 } }
+  )
 })
 
 describe("checkIsMonorepo", () => {
@@ -469,4 +664,44 @@ describe("normalizeDependencyVersion", () => {
   it("trim whitespace and strip the workspace prefix", () => {
     expect(normalizeDependencyVersion("  workspace:^0.20.0  ")).toBe("0.20.0")
   })
+
+  // The input domain is real dependency specifiers: optional whitespace padding, an optional
+  // `workspace:` protocol, and at most one range prefix. Stacked prefixes like `~~1.0.0` are not
+  // valid specifiers and are out of scope.
+  const version = FastCheck.tuple(
+    FastCheck.nat({ max: 99 }),
+    FastCheck.nat({ max: 99 }),
+    FastCheck.nat({ max: 99 }),
+    FastCheck.option(FastCheck.constantFrom("-alpha", "-beta.1", "-rc.0"))
+  ).map(([major, minor, patch, prerelease]) => `${major}.${minor}.${patch}${prerelease ?? ""}`)
+  const specifierParts = {
+    padding: FastCheck.constantFrom("", " ", "  ", "\t"),
+    rangePrefix: FastCheck.constantFrom("", "^", "~"),
+    version,
+    workspacePrefix: FastCheck.constantFrom("", "workspace:"),
+  }
+
+  it.prop(
+    "recover the exact version from any padded, prefixed specifier",
+    specifierParts,
+    ({ padding, rangePrefix, version: versionCore, workspacePrefix }) => {
+      const specifier = `${padding}${workspacePrefix}${rangePrefix}${versionCore}${padding}`
+
+      expect(normalizeDependencyVersion(specifier)).toBe(versionCore)
+    },
+    { fastCheck: { numRuns: 500 } }
+  )
+
+  it.prop(
+    "be idempotent on the specifier domain",
+    specifierParts,
+    ({ padding, rangePrefix, version: versionCore, workspacePrefix }) => {
+      const once = normalizeDependencyVersion(
+        `${padding}${workspacePrefix}${rangePrefix}${versionCore}${padding}`
+      )
+
+      expect(normalizeDependencyVersion(once)).toBe(once)
+    },
+    { fastCheck: { numRuns: 500 } }
+  )
 })

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -34,6 +34,8 @@ function someKey(value: JsonValue, predicate: (key: string) => boolean): boolean
 // SAFETY: fast-check's JsonValue and type-fest's JsonValue describe the same JSON data shapes.
 const jsonValueArbitrary = FastCheck.jsonValue({ maxDepth: 4 }).map((value) => value as JsonValue)
 
+// Evaluates through a data: URI module import instead of `new Function` so the oracle stays
+// within the repo's no-eval lint policy without disable comments.
 async function evaluateTsLiteral(serialized: string): Promise<JsonValue> {
   const uri = `data:text/javascript,export default (${encodeURIComponent(serialized)})`
   // SAFETY: the module evaluates a serialized JSON value, so its default export is a JsonValue.
@@ -441,14 +443,14 @@ describe("serializeTsObjectLiteral", () => {
   // Both known bugs come from the key-unquoting regex matching text it should not: the escaped
   // quote in a serialized key produces a bare `"A":` substring, and `__proto__` is a valid
   // identifier but means prototype assignment once unquoted.
-  it.fails("known bug: a key containing a double quote produces invalid syntax", async () => {
+  it.fails("known bug (#385): a key containing a double quote produces invalid syntax", async () => {
     const value = { '"A': null }
     const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))
 
     expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
   })
 
-  it.fails("known bug: an unquoted __proto__ key changes the evaluated object", async () => {
+  it.fails("known bug (#385): an unquoted __proto__ key changes the evaluated object", async () => {
     // SAFETY: JSON.parse creates `__proto__` as an own property, unlike an object literal.
     const value = JSON.parse('{"__proto__": {"polluted": true}}') as JsonValue
     const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))

--- a/src/lib/migrations/__tests__/hardcoded-node-version.test.ts
+++ b/src/lib/migrations/__tests__/hardcoded-node-version.test.ts
@@ -1,11 +1,19 @@
+import type { PackageJson } from "type-fest"
 import { describe, expect, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import { createDependencyInstallerTestContext } from "#commands/__tests__/command-test-helpers.ts"
+import github from "#lib/integrations/ci/github.ts"
 import migrationHardcodedNodeVersion from "#lib/migrations/hardcoded-node-version.ts"
 import { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
+import {
+  MANAGED_SCRIPT_COMMANDS,
+  type Script,
+  type SupportedPackageManager,
+} from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -195,5 +203,55 @@ describe("hardcodedNodeVersion", () => {
         ],
       })
     })
+  )
+
+  // A freshly generated workflow must never be flagged by this migration, or `adamantite update`
+  // would loop: regenerate, flag, regenerate again.
+  it.effect.prop(
+    "check never flags a workflow that github.create just generated",
+    {
+      nodeDeclaration: FastCheck.constantFrom("none", "node-version", "nvmrc", "engines"),
+      packageManager: FastCheck.constantFrom<SupportedPackageManager>(
+        "bun",
+        "deno",
+        "npm",
+        "pnpm",
+        "yarn"
+      ),
+      // SAFETY: MANAGED_SCRIPT_COMMANDS is a Record<Script, string>, so its keys are Script values.
+      scripts: FastCheck.subarray(Object.keys(MANAGED_SCRIPT_COMMANDS) as Script[]),
+    },
+    ({ nodeDeclaration, packageManager, scripts }) =>
+      Effect.gen(function* () {
+        const manifest: PackageJson = {
+          name: "test-project",
+          scripts: Object.fromEntries(
+            scripts.map((script) => [script, MANAGED_SCRIPT_COMMANDS[script]])
+          ),
+          version: "1.0.0",
+        }
+        if (nodeDeclaration === "engines") {
+          manifest.engines = { node: ">=22" }
+        }
+
+        const fixtures: Record<string, string> = {}
+        fixtures["package.json"] = JSON.stringify(manifest, null, 2)
+        if (nodeDeclaration === "node-version") {
+          fixtures[".node-version"] = "22.19.0\n"
+        }
+        if (nodeDeclaration === "nvmrc") {
+          fixtures[".nvmrc"] = "20\n"
+        }
+        const files = makeFiles(fixtures)
+
+        yield* github.create(ROOT, { packageManager, scripts }).pipe(provideServices(files))
+
+        const result = yield* migrationHardcodedNodeVersion
+          .check({ cwd: ROOT })
+          .pipe(provideServices(files, { detectedPackageManager: { name: packageManager } }))
+
+        expect(result).toEqual({ status: "not-applicable", warnings: [] })
+      }),
+    { fastCheck: { numRuns: 150 } }
   )
 })

--- a/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
+++ b/src/lib/migrations/__tests__/legacy-typecheck-script.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import { createDependencyInstallerTestContext } from "#commands/__tests__/command-test-helpers.ts"
 import migrationLegacyOxlintJson from "#lib/migrations/legacy-oxlint-json.ts"
@@ -228,5 +229,86 @@ describe("legacyTypecheckScript", () => {
       expect(workflow).toContain("name: format")
       expect(workflow).not.toContain("name: types")
     })
+  )
+
+  const otherScripts = FastCheck.dictionary(
+    FastCheck.constantFrom("build", "dev", "lint", "check", "format"),
+    FastCheck.constantFrom("adamantite check", "adamantite format", "", "tsc -b", "eslint ."),
+    { maxKeys: 5 }
+  )
+  const manifestFields = {
+    dependencies: FastCheck.constantFrom({}, { react: "^18.0.0" }),
+    name: FastCheck.constantFrom("test-project", "@scope/pkg"),
+  }
+
+  it.effect.prop(
+    "check reports needed exactly when the legacy typecheck command is present",
+    {
+      ...manifestFields,
+      scripts: otherScripts,
+      typecheckCommand: FastCheck.option(
+        FastCheck.constantFrom("adamantite typecheck", "tsc --noEmit", "")
+      ),
+    },
+    ({ dependencies, name, scripts, typecheckCommand }) =>
+      Effect.gen(function* () {
+        const scriptsField = { ...scripts }
+        if (typecheckCommand !== null) {
+          scriptsField.typecheck = typecheckCommand
+        }
+        const manifest = {
+          dependencies,
+          name,
+          scripts: scriptsField,
+          version: "1.0.0",
+        }
+        const files = makeFiles({ "package.json": JSON.stringify(manifest, null, 2) })
+
+        const result = yield* migrationLegacyTypecheckScript
+          .check({ cwd: ROOT })
+          .pipe(provideServices(files))
+
+        expect(result.status).toBe(
+          typecheckCommand === "adamantite typecheck" ? "needed" : "not-applicable"
+        )
+      }),
+    { fastCheck: { numRuns: 100 } }
+  )
+
+  it.effect.prop(
+    "migrate rewrites only the typecheck and check scripts and preserves everything else",
+    { ...manifestFields, scripts: otherScripts },
+    ({ dependencies, name, scripts }) =>
+      Effect.gen(function* () {
+        const manifest = {
+          dependencies,
+          name,
+          scripts: { ...scripts, typecheck: "adamantite typecheck" },
+          version: "1.0.0",
+        }
+        const files = makeFiles({ "package.json": JSON.stringify(manifest, null, 2) })
+
+        yield* migrationLegacyTypecheckScript.migrate({ cwd: ROOT }).pipe(provideServices(files))
+
+        // SAFETY: the test seeds package.json above, and the migration only rewrites scripts.
+        const migrated = JSON.parse(files.read("package.json")) as typeof manifest
+
+        expect(migrated.scripts).toEqual({
+          ...scripts,
+          // `??=` only fills a missing check script; an existing command (even "") is preserved.
+          check: scripts.check ?? "adamantite check",
+        })
+        expect(migrated.name).toBe(name)
+        expect(migrated.dependencies).toEqual(dependencies)
+        expect(migrated.version).toBe("1.0.0")
+
+        yield* migrationLegacyTypecheckScript.validate({ cwd: ROOT }).pipe(provideServices(files))
+
+        const secondCheck = yield* migrationLegacyTypecheckScript
+          .check({ cwd: ROOT })
+          .pipe(provideServices(files))
+        expect(secondCheck.status).toBe("not-applicable")
+      }),
+    { fastCheck: { numRuns: 60 } }
   )
 })

--- a/src/lib/workspace/__tests__/agents.test.ts
+++ b/src/lib/workspace/__tests__/agents.test.ts
@@ -4,6 +4,8 @@ import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as PlatformError from "effect/PlatformError"
+import { FastCheck } from "effect/testing"
+import type { Script } from "#lib/workspace/package-json.ts"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import {
   ADAMANTITE_AGENTS_END_MARKER,
@@ -217,5 +219,109 @@ describe("writeAgentsGuidance", () => {
       const agents = files.read("AGENTS.md")
       expect(agents).toContain("Run `npm run format` after editing files")
     })
+  )
+
+  const ALL_SCRIPTS: Script[] = [
+    "format",
+    "check",
+    "fix",
+    "analyze",
+    "check:monorepo",
+    "fix:monorepo",
+  ]
+  const guidanceOptions = {
+    packageManager: FastCheck.constantFrom("bun", "deno", "npm", "pnpm", "yarn"),
+    scripts: FastCheck.subarray(ALL_SCRIPTS),
+  }
+  // Marker-free so generated content cannot collide with the managed block by accident.
+  const markerFreeContent = FastCheck.string({ maxLength: 200 }).filter(
+    (content) => !content.includes("ADAMANTITE")
+  )
+
+  it.effect.prop(
+    "preserve marker-free content verbatim and append exactly one managed block",
+    { ...guidanceOptions, existing: markerFreeContent },
+    ({ existing, packageManager, scripts }) =>
+      Effect.gen(function* () {
+        const files = makeFiles({ "AGENTS.md": existing })
+
+        const result = yield* runWriteAgentsGuidance(files, { packageManager, scripts })
+
+        expect(result).toBe("updated")
+
+        const agents = files.read("AGENTS.md")
+        expect(agents.startsWith(existing)).toBe(true)
+        expect(countOccurrences(agents, ADAMANTITE_AGENTS_START_MARKER)).toBe(1)
+        expect(countOccurrences(agents, ADAMANTITE_AGENTS_END_MARKER)).toBe(1)
+        expect(agents.endsWith("\n")).toBe(true)
+      }),
+    { fastCheck: { numRuns: 150 } }
+  )
+
+  it.effect.prop(
+    "write the same content no matter how often it runs",
+    { ...guidanceOptions, existing: markerFreeContent },
+    ({ existing, packageManager, scripts }) =>
+      Effect.gen(function* () {
+        const files = makeFiles({ "AGENTS.md": existing })
+
+        yield* runWriteAgentsGuidance(files, { packageManager, scripts })
+        const afterFirst = files.read("AGENTS.md")
+
+        const result = yield* runWriteAgentsGuidance(files, { packageManager, scripts })
+        expect(result).toBe("updated")
+        expect(files.read("AGENTS.md")).toBe(afterFirst)
+      }),
+    { fastCheck: { numRuns: 150 } }
+  )
+
+  it.effect.prop(
+    "replace only the managed block, keeping surrounding content intact",
+    { ...guidanceOptions, prefix: markerFreeContent, suffix: markerFreeContent },
+    ({ packageManager, prefix, scripts, suffix }) =>
+      Effect.gen(function* () {
+        const existing = `${prefix}${ADAMANTITE_AGENTS_START_MARKER}\nOLD-CONTENT-SENTINEL\n${ADAMANTITE_AGENTS_END_MARKER}${suffix}`
+        const files = makeFiles({ "AGENTS.md": existing })
+
+        const result = yield* runWriteAgentsGuidance(files, { packageManager, scripts })
+
+        expect(result).toBe("updated")
+
+        const agents = files.read("AGENTS.md")
+        expect(agents.startsWith(prefix)).toBe(true)
+        expect(agents).not.toContain("OLD-CONTENT-SENTINEL")
+        expect(countOccurrences(agents, ADAMANTITE_AGENTS_START_MARKER)).toBe(1)
+        expect(countOccurrences(agents, ADAMANTITE_AGENTS_END_MARKER)).toBe(1)
+
+        expect(agents.endsWith(suffix) || agents.endsWith(`${suffix}\n`)).toBe(true)
+        expect(agents.endsWith("\n")).toBe(true)
+      }),
+    { fastCheck: { numRuns: 150 } }
+  )
+
+  it.effect.prop(
+    "report malformed markers without touching the file",
+    {
+      ...guidanceOptions,
+      prefix: markerFreeContent,
+      suffix: markerFreeContent,
+      variant: FastCheck.constantFrom("start-only", "end-only", "end-before-start"),
+    },
+    ({ packageManager, prefix, scripts, suffix, variant }) =>
+      Effect.gen(function* () {
+        const existing =
+          variant === "start-only"
+            ? `${prefix}${ADAMANTITE_AGENTS_START_MARKER}${suffix}`
+            : variant === "end-only"
+              ? `${prefix}${ADAMANTITE_AGENTS_END_MARKER}${suffix}`
+              : `${prefix}${ADAMANTITE_AGENTS_END_MARKER}\n${ADAMANTITE_AGENTS_START_MARKER}${suffix}`
+        const files = makeFiles({ "AGENTS.md": existing })
+
+        const result = yield* runWriteAgentsGuidance(files, { packageManager, scripts })
+
+        expect(result).toBe("malformed")
+        expect(files.read("AGENTS.md")).toBe(existing)
+      }),
+    { fastCheck: { numRuns: 150 } }
   )
 })

--- a/src/lib/workspace/__tests__/agents.test.ts
+++ b/src/lib/workspace/__tests__/agents.test.ts
@@ -5,13 +5,13 @@ import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as PlatformError from "effect/PlatformError"
 import { FastCheck } from "effect/testing"
-import type { Script } from "#lib/workspace/package-json.ts"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import {
   ADAMANTITE_AGENTS_END_MARKER,
   ADAMANTITE_AGENTS_START_MARKER,
   writeAgentsGuidance,
 } from "#lib/workspace/agents.ts"
+import { MANAGED_SCRIPT_COMMANDS, type Script } from "#lib/workspace/package-json.ts"
 
 const ROOT = "/project"
 
@@ -254,6 +254,17 @@ describe("writeAgentsGuidance", () => {
         expect(countOccurrences(agents, ADAMANTITE_AGENTS_START_MARKER)).toBe(1)
         expect(countOccurrences(agents, ADAMANTITE_AGENTS_END_MARKER)).toBe(1)
         expect(agents.endsWith("\n")).toBe(true)
+
+        // The block body lists guidance for exactly the selected scripts, with commands that
+        // invoke the selected package manager.
+        for (const script of ALL_SCRIPTS) {
+          expect(agents.includes(`Direct command: \`${MANAGED_SCRIPT_COMMANDS[script]}\`.`)).toBe(
+            scripts.includes(script)
+          )
+        }
+        if (scripts.length > 0) {
+          expect(agents).toContain(`${packageManager} `)
+        }
       }),
     { fastCheck: { numRuns: 150 } }
   )

--- a/src/lib/workspace/__tests__/ci-scripts.test.ts
+++ b/src/lib/workspace/__tests__/ci-scripts.test.ts
@@ -49,6 +49,9 @@ describe("CI workflow entries", () => {
       const entries = getCIWorkflowEntries(manager, selected)
 
       expect(entries.length > 0).toBe(hasCICompatibleScripts(selected))
+      for (const entry of entries) {
+        expect(entry.command).toContain(manager)
+      }
     },
     { fastCheck: { numRuns: 300 } }
   )

--- a/src/lib/workspace/__tests__/ci-scripts.test.ts
+++ b/src/lib/workspace/__tests__/ci-scripts.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from "@effect/vitest"
-import { hasCICompatibleScripts } from "#lib/workspace/ci-scripts.ts"
+import { describe, expect, it, test } from "@effect/vitest"
+import * as EffectArray from "effect/Array"
+import { FastCheck } from "effect/testing"
+import { getCIWorkflowEntries, hasCICompatibleScripts } from "#lib/workspace/ci-scripts.ts"
+import {
+  MANAGED_SCRIPT_COMMANDS,
+  type Script,
+  type SupportedPackageManager,
+} from "#lib/workspace/package-json.ts"
 
 describe("hasCICompatibleScripts", () => {
   test("return true when the check script is present", () => {
@@ -25,4 +32,53 @@ describe("hasCICompatibleScripts", () => {
   test("return true when CI and non-CI scripts are mixed", () => {
     expect(hasCICompatibleScripts(["fix", "check", "fix:monorepo"])).toBe(true)
   })
+})
+
+describe("CI workflow entries", () => {
+  // SAFETY: MANAGED_SCRIPT_COMMANDS is a Record<Script, string>, so its keys are Script values.
+  const ALL_SCRIPTS = Object.keys(MANAGED_SCRIPT_COMMANDS) as Script[]
+  const PACKAGE_MANAGERS: SupportedPackageManager[] = ["bun", "deno", "npm", "pnpm", "yarn"]
+
+  const packageManager = FastCheck.constantFrom(...PACKAGE_MANAGERS)
+  const scripts = FastCheck.subarray(ALL_SCRIPTS)
+
+  it.prop(
+    "agree with hasCICompatibleScripts for every package manager and script subset",
+    { packageManager, scripts },
+    ({ packageManager: manager, scripts: selected }) => {
+      const entries = getCIWorkflowEntries(manager, selected)
+
+      expect(entries.length > 0).toBe(hasCICompatibleScripts(selected))
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  it.prop(
+    "produce uniquely named entries independent of script order",
+    { packageManager, scripts },
+    ({ packageManager: manager, scripts: selected }) => {
+      const entries = getCIWorkflowEntries(manager, selected)
+      const reversed = getCIWorkflowEntries(manager, EffectArray.reverse(selected))
+
+      expect(reversed).toEqual(entries)
+      expect(new Set(entries.map((entry) => entry.name)).size).toBe(entries.length)
+      expect(entries.length).toBeLessThanOrEqual(selected.length)
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  it.prop(
+    "never lose an entry when more scripts are requested",
+    { extra: FastCheck.subarray(ALL_SCRIPTS), packageManager, scripts },
+    ({ extra, packageManager: manager, scripts: selected }) => {
+      const baseline = getCIWorkflowEntries(manager, selected)
+      const expanded = getCIWorkflowEntries(manager, [...selected, ...extra])
+      const expandedNames = new Set(expanded.map((entry) => entry.name))
+
+      for (const entry of baseline) {
+        expect(expandedNames).toContain(entry.name)
+      }
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
 })

--- a/src/lib/workspace/__tests__/node-version-resolver.test.ts
+++ b/src/lib/workspace/__tests__/node-version-resolver.test.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as PlatformError from "effect/PlatformError"
 import * as Result from "effect/Result"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import { NodeVersionResolver } from "#lib/workspace/node-version-resolver.ts"
 
@@ -243,5 +244,187 @@ describe("NodeVersionResolver", () => {
         expect(result.failure).toMatchObject({ _tag: "FailedToParseFile" })
       }
     })
+  )
+
+  const nodeLine = FastCheck.tuple(
+    FastCheck.constantFrom("", "  ", "\t"),
+    FastCheck.constantFrom("node", "nodejs"),
+    FastCheck.constantFrom(" ", "  ", "\t"),
+    FastCheck.constantFrom("22.19.0", "22", "lts/iron"),
+    FastCheck.constantFrom("", "  ", " # pinned")
+  ).map((parts) => parts.join(""))
+  // Lines the parser must ignore: comments, other tools, node-prefixed tool names, and bare
+  // `node` entries without a version.
+  const inertLine = FastCheck.constantFrom(
+    "",
+    "# pinned tools",
+    "  # node 22.19.0",
+    "python 3.12.0",
+    "ruby 3.3.0  # main",
+    "node",
+    "nodejs",
+    "node-canvas 1.0.0",
+    "gonode 1.0.0"
+  )
+
+  it.effect.prop(
+    "detect a .tool-versions node entry regardless of surrounding noise",
+    {
+      hasNode: FastCheck.boolean(),
+      lines: FastCheck.array(inertLine, { maxLength: 8 }),
+      node: nodeLine,
+      position: FastCheck.nat({ max: 8 }),
+    },
+    ({ hasNode, lines, node, position }) =>
+      Effect.gen(function* () {
+        const allLines: string[] = [...lines]
+        if (hasNode) {
+          allLines.splice(Math.min(position, allLines.length), 0, node)
+        }
+        const files = makeFiles({ ".tool-versions": allLines.join("\n") })
+
+        const source = yield* runResolve(files)
+
+        expect(source).toEqual(
+          hasNode ? { _tag: "File", path: ".tool-versions" } : { _tag: "Version", value: "lts/*" }
+        )
+      }),
+    { fastCheck: { numRuns: 200 } }
+  )
+
+  const versionFileContent = FastCheck.constantFrom(
+    { content: "22.19.0\n", valid: true },
+    { content: "22\n", valid: true },
+    { content: "", valid: false },
+    { content: "   \n", valid: false }
+  )
+  const toolVersionsContent = FastCheck.constantFrom(
+    { content: "nodejs 22.19.0\n", valid: true },
+    { content: "node 22\n", valid: true },
+    { content: "python 3.12.0\n", valid: false },
+    { content: "# only comments\n", valid: false }
+  )
+  const packageJsonContent = FastCheck.constantFrom(
+    { content: JSON.stringify({ engines: { node: ">=22" }, name: "pkg" }), valid: true },
+    { content: JSON.stringify({ name: "pkg", volta: { node: "22.19.0" } }), valid: true },
+    {
+      content: JSON.stringify({
+        devEngines: { runtime: { name: "node", version: "22" } },
+        name: "pkg",
+      }),
+      valid: true,
+    },
+    { content: JSON.stringify({ name: "pkg" }), valid: false }
+  )
+
+  it.effect.prop(
+    "resolve the highest-precedence valid declaration for any file combination",
+    {
+      nodeVersion: FastCheck.option(versionFileContent),
+      nvmrc: FastCheck.option(versionFileContent),
+      packageJson: FastCheck.option(packageJsonContent),
+      toolVersions: FastCheck.option(toolVersionsContent),
+    },
+    ({ nodeVersion, nvmrc, packageJson, toolVersions }) =>
+      Effect.gen(function* () {
+        const fixtures: Record<string, string> = {}
+        if (nodeVersion) {
+          fixtures[".node-version"] = nodeVersion.content
+        }
+        if (nvmrc) {
+          fixtures[".nvmrc"] = nvmrc.content
+        }
+        if (toolVersions) {
+          fixtures[".tool-versions"] = toolVersions.content
+        }
+        if (packageJson) {
+          fixtures["package.json"] = packageJson.content
+        }
+        const files = makeFiles(fixtures)
+
+        const source = yield* runResolve(files)
+
+        const expected = nodeVersion?.valid
+          ? { _tag: "File", path: ".node-version" }
+          : nvmrc?.valid
+            ? { _tag: "File", path: ".nvmrc" }
+            : toolVersions?.valid
+              ? { _tag: "File", path: ".tool-versions" }
+              : packageJson?.valid
+                ? { _tag: "File", path: "package.json" }
+                : { _tag: "Version", value: "lts/*" }
+        expect(source).toEqual(expected)
+      }),
+    { fastCheck: { numRuns: 200 } }
+  )
+
+  const nonEmptyVersion = FastCheck.constantFrom("22.19.0", ">=22", "lts/*")
+  const declaringManifest = FastCheck.oneof(
+    nonEmptyVersion.map((node) => ({ volta: { node } })),
+    nonEmptyVersion.map((node) => ({ engines: { node } })),
+    FastCheck.tuple(FastCheck.constantFrom("node", "Node", "NODE"), nonEmptyVersion).map(
+      ([name, version]) => ({ devEngines: { runtime: { name, version } } })
+    ),
+    nonEmptyVersion.map((version) => ({
+      devEngines: {
+        runtime: [
+          { name: "deno", version: "2.0.0" },
+          { name: "node", version },
+        ],
+      },
+    }))
+  )
+  const nonDeclaringManifest = FastCheck.constantFrom(
+    {},
+    { engines: {} },
+    { engines: { node: "" } },
+    { volta: {} },
+    { volta: { node: "" } },
+    { devEngines: {} },
+    { devEngines: { runtime: { name: "bun", version: "1.2.0" } } },
+    { devEngines: { runtime: { name: "node" } } },
+    { devEngines: { runtime: [{ name: "deno", version: "2.0.0" }] } }
+  )
+
+  it.effect.prop(
+    "recognize every supported package.json declaration shape",
+    { manifest: declaringManifest },
+    ({ manifest }) =>
+      Effect.gen(function* () {
+        const files = makeFiles({ "package.json": JSON.stringify({ name: "pkg", ...manifest }) })
+
+        const source = yield* runResolve(files)
+
+        expect(source).toEqual({ _tag: "File", path: "package.json" })
+      }),
+    { fastCheck: { numRuns: 200 } }
+  )
+
+  it.effect.prop(
+    "fall back to lts/* when package.json declares nothing",
+    { manifest: nonDeclaringManifest },
+    ({ manifest }) =>
+      Effect.gen(function* () {
+        const files = makeFiles({ "package.json": JSON.stringify({ name: "pkg", ...manifest }) })
+
+        const source = yield* runResolve(files)
+
+        expect(source).toEqual({ _tag: "Version", value: "lts/*" })
+      }),
+    { fastCheck: { numRuns: 100 } }
+  )
+
+  it.effect.prop(
+    "resolve without failing for arbitrary package.json JSON",
+    { value: FastCheck.jsonValue({ maxDepth: 3 }) },
+    ({ value }) =>
+      Effect.gen(function* () {
+        const files = makeFiles({ "package.json": JSON.stringify(value) })
+
+        const source = yield* runResolve(files)
+
+        expect(["File", "Version"]).toContain(source._tag)
+      }),
+    { fastCheck: { numRuns: 200 } }
   )
 })

--- a/src/lib/workspace/__tests__/node-version-resolver.test.ts
+++ b/src/lib/workspace/__tests__/node-version-resolver.test.ts
@@ -254,11 +254,14 @@ describe("NodeVersionResolver", () => {
     FastCheck.constantFrom("", "  ", " # pinned")
   ).map((parts) => parts.join(""))
   // Lines the parser must ignore: comments, other tools, node-prefixed tool names, and bare
-  // `node` entries without a version.
+  // `node` entries without a version. The `node # pinned` shapes stay inert only when comments
+  // are stripped before matching, so they keep the comment handling load-bearing.
   const inertLine = FastCheck.constantFrom(
     "",
     "# pinned tools",
     "  # node 22.19.0",
+    "node # pinned",
+    "nodejs\t# 22.19.0",
     "python 3.12.0",
     "ruby 3.3.0  # main",
     "node",

--- a/src/lib/workspace/__tests__/package-json.test.ts
+++ b/src/lib/workspace/__tests__/package-json.test.ts
@@ -107,17 +107,23 @@ describe("script management", () => {
   )
 
   it.prop(
-    "only report requested scripts whose non-empty command differs from the managed one",
+    "report exactly the requested scripts whose non-empty command differs from the managed one",
     { manifest, requested: requestedScripts },
     ({ manifest: packageJson, requested }) => {
       const conflicts = getConflictingScripts(packageJson, requested)
 
       for (const conflict of conflicts) {
-        expect(requested).toContain(conflict.script)
-        expect(conflict.command).not.toBe("")
-        expect(conflict.command).not.toBe(MANAGED_SCRIPT_COMMANDS[conflict.script])
-        expect(packageJson.scripts?.[conflict.script]).toBe(conflict.command)
+        expect(conflict.command).toBe(packageJson.scripts?.[conflict.script])
       }
+
+      const expectedConflicting = requested.filter((script) => {
+        const command = packageJson.scripts?.[script]
+
+        return (
+          command !== undefined && command !== "" && command !== MANAGED_SCRIPT_COMMANDS[script]
+        )
+      })
+      expect(conflicts.map((conflict) => conflict.script)).toEqual(expectedConflicting)
     },
     { fastCheck: { numRuns: 300 } }
   )

--- a/src/lib/workspace/__tests__/package-json.test.ts
+++ b/src/lib/workspace/__tests__/package-json.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from "@effect/vitest"
-import { getConflictingScripts } from "#lib/workspace/package-json.ts"
+import type { PackageJson } from "type-fest"
+import { describe, expect, it, test } from "@effect/vitest"
+import { FastCheck } from "effect/testing"
+import {
+  getConflictingScripts,
+  getManagedScripts,
+  MANAGED_SCRIPT_COMMANDS,
+  type Script,
+} from "#lib/workspace/package-json.ts"
 
 describe("getConflictingScripts", () => {
   test("returns scripts whose existing command differs from the managed command", () => {
@@ -63,4 +70,75 @@ describe("getConflictingScripts", () => {
 
     expect(conflicts).toEqual([{ command: "prettier --write .", script: "format" }])
   })
+})
+
+describe("script management", () => {
+  // SAFETY: MANAGED_SCRIPT_COMMANDS is a Record<Script, string>, so its keys are Script values.
+  const ALL_SCRIPTS = Object.keys(MANAGED_SCRIPT_COMMANDS) as Script[]
+
+  const requestedScripts = FastCheck.subarray(ALL_SCRIPTS)
+  const scriptCommand = FastCheck.oneof(
+    FastCheck.constantFrom(...Object.values(MANAGED_SCRIPT_COMMANDS)),
+    FastCheck.constantFrom("", "tsc && eslint .", "prettier --write ."),
+    FastCheck.string()
+  )
+  const manifestScripts = FastCheck.dictionary(
+    FastCheck.oneof(
+      FastCheck.constantFrom<string>(...ALL_SCRIPTS),
+      FastCheck.constantFrom("build", "dev", "test")
+    ),
+    scriptCommand,
+    { maxKeys: 9 }
+  )
+  const manifest = manifestScripts.map((scripts): PackageJson => ({ name: "fixture", scripts }))
+
+  it.prop(
+    "never report a script as both managed and conflicting",
+    { manifest, requested: requestedScripts },
+    ({ manifest: packageJson, requested }) => {
+      const managed = getManagedScripts(packageJson)
+      const conflicts = getConflictingScripts(packageJson, requested)
+
+      for (const conflict of conflicts) {
+        expect(managed).not.toContain(conflict.script)
+      }
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  it.prop(
+    "only report requested scripts whose non-empty command differs from the managed one",
+    { manifest, requested: requestedScripts },
+    ({ manifest: packageJson, requested }) => {
+      const conflicts = getConflictingScripts(packageJson, requested)
+
+      for (const conflict of conflicts) {
+        expect(requested).toContain(conflict.script)
+        expect(conflict.command).not.toBe("")
+        expect(conflict.command).not.toBe(MANAGED_SCRIPT_COMMANDS[conflict.script])
+        expect(packageJson.scripts?.[conflict.script]).toBe(conflict.command)
+      }
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
+
+  it.prop(
+    "leave nothing conflicting once the managed commands are adopted",
+    { requested: requestedScripts, scripts: manifestScripts },
+    ({ requested, scripts }) => {
+      const adoptedScripts = { ...scripts }
+      for (const script of requested) {
+        adoptedScripts[script] = MANAGED_SCRIPT_COMMANDS[script]
+      }
+      const adopted: PackageJson = { name: "fixture", scripts: adoptedScripts }
+
+      expect(getConflictingScripts(adopted, requested)).toEqual([])
+
+      const managed = getManagedScripts(adopted)
+      for (const script of requested) {
+        expect(managed).toContain(script)
+      }
+    },
+    { fastCheck: { numRuns: 300 } }
+  )
 })

--- a/src/lib/workspace/__tests__/tsconfig.test.ts
+++ b/src/lib/workspace/__tests__/tsconfig.test.ts
@@ -1,8 +1,10 @@
+import type { TsConfigJson } from "type-fest"
 import { describe, expect, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Path from "effect/Path"
 import * as Result from "effect/Result"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import tsconfig from "#lib/workspace/tsconfig.ts"
 
@@ -228,4 +230,79 @@ describe("tsconfig", () => {
       })
     )
   })
+})
+
+function readTsConfig(files: FileSystemTestContext): TsConfigJson {
+  // SAFETY: the test seeds tsconfig.json with standard tsconfig fields, and update writes JSON of
+  // the same shape back.
+  return JSON.parse(files.read("tsconfig.json")) as TsConfigJson
+}
+
+function readExtends(files: FileSystemTestContext): string[] {
+  const extendsValue = readTsConfig(files).extends ?? []
+
+  return Array.isArray(extendsValue) ? extendsValue : [extendsValue]
+}
+
+describe("tsconfig update properties", () => {
+  const PRESET = "adamantite/typescript"
+
+  const userExtends = FastCheck.oneof(
+    FastCheck.constant(null),
+    FastCheck.constantFrom(PRESET, "@tsconfig/node22/tsconfig.json", "./base.json"),
+    FastCheck.subarray(["@tsconfig/node22/tsconfig.json", "./base.json", PRESET, "./other.json"])
+  )
+  const userConfig = FastCheck.record({
+    compilerOptions: FastCheck.constantFrom(
+      { strict: true },
+      { module: "esnext", strict: false },
+      {}
+    ),
+    include: FastCheck.constantFrom(["src/**/*"], ["src", "test"]),
+  })
+
+  it.effect.prop(
+    "keep user extends entries in order and add the preset exactly once",
+    { config: userConfig, extendsValue: userExtends },
+    ({ config, extendsValue }) =>
+      Effect.gen(function* () {
+        const original = extendsValue === null ? config : { ...config, extends: extendsValue }
+        const files = makeFiles({ "tsconfig.json": JSON.stringify(original) })
+
+        yield* tsconfig.update(ROOT).pipe(provideFiles(files))
+
+        const mergedExtends = readExtends(files)
+        expect(mergedExtends.filter((entry) => entry === PRESET)).toHaveLength(1)
+
+        const userEntries =
+          extendsValue === null
+            ? []
+            : (Array.isArray(extendsValue) ? extendsValue : [extendsValue]).filter(
+                (entry) => entry !== PRESET
+              )
+        expect(mergedExtends.filter((entry) => entry !== PRESET)).toEqual(userEntries)
+
+        const parsed = readTsConfig(files)
+        expect(parsed.compilerOptions).toEqual(config.compilerOptions)
+        expect(parsed.include).toEqual(config.include)
+      }),
+    { fastCheck: { numRuns: 150 } }
+  )
+
+  it.effect.prop(
+    "write the same config no matter how often update runs",
+    { config: userConfig, extendsValue: userExtends },
+    ({ config, extendsValue }) =>
+      Effect.gen(function* () {
+        const original = extendsValue === null ? config : { ...config, extends: extendsValue }
+        const files = makeFiles({ "tsconfig.json": JSON.stringify(original) })
+
+        yield* tsconfig.update(ROOT).pipe(provideFiles(files))
+        const afterFirst = files.read("tsconfig.json")
+
+        yield* tsconfig.update(ROOT).pipe(provideFiles(files))
+        expect(files.read("tsconfig.json")).toBe(afterFirst)
+      }),
+    { fastCheck: { numRuns: 150 } }
+  )
 })

--- a/src/lib/workspace/tooling/__tests__/config.test.ts
+++ b/src/lib/workspace/tooling/__tests__/config.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "@effect/vitest"
+import * as EffectArray from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
+import * as Order from "effect/Order"
 import * as Path from "effect/Path"
+import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
 import {
   detectToolingConfig,
@@ -138,6 +141,58 @@ describe("detectToolingConfig", () => {
       ])
     })
   )
+
+  it.effect.prop(
+    "follow ts > jsonc > json precedence for every combination of present files",
+    {
+      hasJson: FastCheck.boolean(),
+      hasJsonc: FastCheck.boolean(),
+      hasTs: FastCheck.boolean(),
+      legacyOrder: FastCheck.constantFrom<string[]>(
+        ["tool.json", "tool.jsonc"],
+        ["tool.jsonc", "tool.json"]
+      ),
+    },
+    ({ hasJson, hasJsonc, hasTs, legacyOrder }) =>
+      Effect.gen(function* () {
+        const fixtures: Record<string, string> = {}
+        if (hasTs) {
+          fixtures["tool.config.ts"] = "export default {}\n"
+        }
+        if (hasJsonc) {
+          fixtures["tool.jsonc"] = "{}\n"
+        }
+        if (hasJson) {
+          fixtures["tool.json"] = "{}\n"
+        }
+        const files = makeFiles(fixtures)
+
+        const state = yield* detect(files, { config: "tool.config.ts", legacyConfigs: legacyOrder })
+
+        const expectedActive = hasTs
+          ? "tool.config.ts"
+          : hasJsonc
+            ? "tool.jsonc"
+            : hasJson
+              ? "tool.json"
+              : null
+        expect(state.active?.file ?? null).toBe(expectedActive)
+
+        const expectedLegacy = [hasJson ? "tool.json" : null, hasJsonc ? "tool.jsonc" : null]
+          .filter((file) => file !== null)
+          .filter((file) => file !== expectedActive)
+        expect(
+          EffectArray.sort(
+            state.legacy.map((entry) => entry.file),
+            Order.String
+          )
+        ).toEqual(EffectArray.sort(expectedLegacy, Order.String))
+
+        const hasWarnings = expectedActive !== null && expectedLegacy.length > 0
+        expect(state.warnings.length > 0).toBe(hasWarnings)
+      }),
+    { fastCheck: { numRuns: 100 } }
+  )
 })
 
 describe("getPackageActions", () => {
@@ -172,6 +227,44 @@ describe("getPackageActions", () => {
       getPackageActions({ dependencies: { tool: "workspace:~1.2.3" } }, pkg, "purpose")
     ).toEqual([])
   })
+
+  const specifier = FastCheck.tuple(
+    FastCheck.constantFrom("", "workspace:"),
+    FastCheck.constantFrom("", "^", "~"),
+    FastCheck.constantFrom("1.2.3", "1.0.0", "2.4.6-beta.1")
+  ).map(([workspacePrefix, rangePrefix, version]) => ({
+    version,
+    written: `${workspacePrefix}${rangePrefix}${version}`,
+  }))
+
+  it.prop(
+    "classify any manifest into exactly one of match, install, or update",
+    {
+      field: FastCheck.constantFrom("dependencies", "devDependencies"),
+      installed: FastCheck.option(specifier),
+    },
+    ({ field, installed }) => {
+      const manifest = installed === null ? {} : { [field]: { tool: installed.written } }
+      const actions = getPackageActions(manifest, pkg, "purpose")
+
+      if (installed === null) {
+        expect(actions).toEqual([
+          expect.objectContaining({ targetVersion: pkg.version, type: "install_package" }),
+        ])
+      } else if (installed.version === pkg.version) {
+        expect(actions).toEqual([])
+      } else {
+        expect(actions).toEqual([
+          expect.objectContaining({
+            currentVersion: installed.written,
+            targetVersion: pkg.version,
+            type: "update_package",
+          }),
+        ])
+      }
+    },
+    { fastCheck: { numRuns: 200 } }
+  )
 })
 
 function state(active: ToolingConfigState["active"]): ToolingConfigState {


### PR DESCRIPTION
The example-based tests pin the cases we thought of, but Adamantite's whole job is handling arbitrary user projects — any package.json, any legacy config, any AGENTS.md. This adds 31 property-based tests that generate those inputs instead, using the fast-check instance already bundled with Effect (`effect/testing/FastCheck`) through `@effect/vitest`'s `it.prop`/`it.effect.prop`. Zero new dependencies; generators live inline next to the properties that use them.

The properties lock in the contracts the tool depends on:

- **Init idempotence**: adopting the managed scripts leaves nothing conflicting, and a script is never both managed and conflicting.
- **Migrations**: `legacy-typecheck-script` rewrites only `typecheck`/`check` and preserves every other manifest field; a freshly generated GitHub workflow is never re-flagged by `hardcoded-node-version` (which would otherwise be an update loop).
- **Resolution**: Node.js version source precedence across every file combination, `.tool-versions` parsing under arbitrary noise, and ts > jsonc > json config detection.
- **Editing**: `writeAgentsGuidance` preserves user content verbatim and is idempotent from any starting state.
- **Consistency**: `hasCICompatibleScripts` agrees with `getCIWorkflowEntries` for every package manager × script subset.

The first runs surfaced four real behaviors. Production code is untouched — each is pinned in the suite instead, so a future fix flips the pin:

1. `serializeTsObjectLiteral` emits **invalid syntax** when a key contains a double quote (shrunk counterexample: `{"\"A": null}`) — the key-unquoting regex matches the bare `"A":` substring inside the escaped key. Pinned with `it.fails`.
2. `serializeTsObjectLiteral` silently **drops own `__proto__` keys**: unquoted `__proto__:` in an object literal means prototype assignment. Pinned with `it.fails`. Both share one fix if we want it (skip escaped contexts and `__proto__` in the regex).
3. `parseJson` strips `__proto__` keys (jsonc-parser pollution protection) — probably desirable, pinned as a documenting test.
4. `mergeConfig` (defu) drops null-valued keys from its **first** argument. Current call sites pass user config second, so this is latent; pinned as a documenting test.

The serializer eval oracle uses a `data:` URI dynamic import rather than `new Function`, keeping the suite clean under the repo's no-eval, no-disables lint policy.

Test suite: 383 passed + 2 expected-fail pins, stable across repeated randomized runs. `check`, `format`, and `analyze` all pass.

Implemented by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)