### PR TITLE
Stop serializeTsObjectLiteral from corrupting quote-containing and __proto__ keys

### DIFF
--- a/.changeset/serialize-hazardous-keys.md
+++ b/.changeset/serialize-hazardous-keys.md
@@ -4,4 +4,4 @@
 
 Fix `serializeTsObjectLiteral` corrupting keys that contain a double quote and dropping own `__proto__` keys
 
-The key-unquoting regex matched escaped quotes inside serialized keys, so migrating a knip or oxfmt config with a quote-containing key produced a `*.config.ts` file with invalid syntax. It also unquoted `__proto__`, which an object literal treats as prototype assignment, so the key vanished from the evaluated config. Quote-containing keys now stay quoted, and `__proto__` keys are emitted as computed properties (`["__proto__"]:`) so they survive as own properties.
+The key-unquoting regex matched escaped quotes inside serialized keys, so migrating a knip or oxfmt config with a quote-containing key produced a `*.config.ts` file with invalid syntax. It also unquoted `__proto__`, which an object literal treats as prototype assignment; the migration path never hits this because `parseJson` strips `__proto__`, but any direct caller would lose the key. Quote-containing keys now stay quoted, and `__proto__` keys are emitted as computed properties (`["__proto__"]:`) so they survive as own properties.

--- a/.changeset/serialize-hazardous-keys.md
+++ b/.changeset/serialize-hazardous-keys.md
@@ -1,0 +1,7 @@
+---
+"adamantite": patch
+---
+
+Fix `serializeTsObjectLiteral` corrupting keys that contain a double quote and dropping own `__proto__` keys
+
+The key-unquoting regex matched escaped quotes inside serialized keys, so migrating a knip or oxfmt config with a quote-containing key produced a `*.config.ts` file with invalid syntax. It also unquoted `__proto__`, which an object literal treats as prototype assignment, so the key vanished from the evaluated config. Quote-containing keys now stay quoted, and `__proto__` keys are emitted as computed properties (`["__proto__"]:`) so they survive as own properties.

--- a/.changeset/writer-key-emission.md
+++ b/.changeset/writer-key-emission.md
@@ -1,0 +1,7 @@
+---
+"adamantite": patch
+---
+
+Fix knip and oxfmt migrations writing non-identifier config keys as bare identifiers
+
+The config writers interpolated keys directly into the generated `*.config.ts`, so a legal knip key such as `lint-staged` or a rule name containing punctuation produced invalid TypeScript. Keys are now emitted through `serializeTsPropertyKey`, which quotes non-identifier keys and writes `__proto__` as a computed property.

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -11,7 +11,12 @@ import * as Result from "effect/Result"
 import * as Terminal from "effect/Terminal"
 import { FastCheck } from "effect/testing"
 import { type FileSystemTestContext, createFileSystemTestContext } from "#__tests__/filesystem.ts"
-import { mergeConfig, parseJson, serializeTsObjectLiteral } from "#lib/shared/json.ts"
+import {
+  mergeConfig,
+  parseJson,
+  serializeTsObjectLiteral,
+  serializeTsPropertyKey,
+} from "#lib/shared/json.ts"
 import { checkIsMonorepo } from "#lib/workspace/monorepo.ts"
 import { normalizeDependencyVersion, readPackageJson } from "#lib/workspace/package-json.ts"
 import { printTitle } from "#terminal/title.ts"
@@ -497,6 +502,26 @@ describe("serializeTsObjectLiteral", () => {
         expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
       }),
     { fastCheck: { numRuns: 500 } }
+  )
+})
+
+describe("serializeTsPropertyKey", () => {
+  it("emit __proto__ as a computed property name", () => {
+    expect(serializeTsPropertyKey("__proto__")).toBe('["__proto__"]')
+  })
+
+  it.effect.prop(
+    "emit a property name that evaluates back to the original key",
+    { key: FastCheck.string() },
+    ({ key }) =>
+      Effect.gen(function* () {
+        const evaluated = yield* Effect.promise(() =>
+          evaluateTsLiteral(`{ ${serializeTsPropertyKey(key)}: 1 }`)
+        )
+
+        expect(JSON.stringify(evaluated)).toBe(JSON.stringify({ [key]: 1 }))
+      }),
+    { fastCheck: { numRuns: 300 } }
   )
 })
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -440,17 +440,14 @@ describe("serializeTsObjectLiteral", () => {
 }`)
   })
 
-  // Both known bugs come from the key-unquoting regex matching text it should not: the escaped
-  // quote in a serialized key produces a bare `"A":` substring, and `__proto__` is a valid
-  // identifier but means prototype assignment once unquoted.
-  it.fails("known bug (#385): a key containing a double quote produces invalid syntax", async () => {
+  it("round-trip keys that contain a double quote (#385)", async () => {
     const value = { '"A': null }
     const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))
 
     expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
   })
 
-  it.fails("known bug (#385): an unquoted __proto__ key changes the evaluated object", async () => {
+  it("keep own __proto__ keys as own properties (#385)", async () => {
     // SAFETY: JSON.parse creates `__proto__` as an own property, unlike an object literal.
     const value = JSON.parse('{"__proto__": {"polluted": true}}') as JsonValue
     const evaluated = await evaluateTsLiteral(serializeTsObjectLiteral(value))
@@ -458,13 +455,9 @@ describe("serializeTsObjectLiteral", () => {
     expect(JSON.stringify(evaluated)).toBe(JSON.stringify(value))
   })
 
-  const hazardFreeJsonValue = jsonValueArbitrary.filter(
-    (value) => !someKey(value, (key) => key.includes('"') || key === "__proto__")
-  )
-
   it.effect.prop(
-    "evaluate back to the original value for any JSON value without hazardous keys",
-    { value: hazardFreeJsonValue },
+    "evaluate back to the original value for any JSON value",
+    { value: jsonValueArbitrary },
     ({ value }) =>
       Effect.gen(function* () {
         const evaluated = yield* Effect.promise(() =>
@@ -477,15 +470,14 @@ describe("serializeTsObjectLiteral", () => {
   )
 
   // Focused generator for the risky surface: identifier-like keys next to string values full of
-  // quotes, backslashes, colons, and braces that the key-unquoting regex could corrupt. Escaping
-  // keeps string values safe; only keys containing a double quote break (pinned above).
+  // quotes, backslashes, colons, and braces that the key-unquoting regex could corrupt.
   const trickyString = FastCheck.array(
     FastCheck.constantFrom('"', "\\", ":", "\n", " ", "a", "$", "_", "{", "}", "'", "`"),
     { maxLength: 12 }
   ).map((chars) => chars.join(""))
   const trickyKey = FastCheck.oneof(
-    FastCheck.constantFrom("enabled", "entry", "$schema", "_private", "a1"),
-    trickyString.map((text) => text.replaceAll('"', ""))
+    FastCheck.constantFrom("enabled", "entry", "$schema", "_private", "a1", "__proto__"),
+    trickyString
   )
   const trickyObject = FastCheck.dictionary(
     trickyKey,

--- a/src/lib/shared/json.ts
+++ b/src/lib/shared/json.ts
@@ -35,10 +35,14 @@ export function serializeTsObjectLiteral(
   } = {}
 ) {
   const { continuationIndent, indentation = 2 } = options
-  const serialized = JSON.stringify(value, null, indentation).replaceAll(
-    /"([A-Za-z_$][\w$]*)":/g,
-    "$1:"
-  )
+  // Both replacements skip quotes preceded by a backslash: an unescaped `"` in
+  // JSON.stringify output is always a real string boundary, so the lookbehind keeps the
+  // rewrites from matching inside keys that contain escaped quotes.
+  const serialized = JSON.stringify(value, null, indentation)
+    // A quoted "__proto__" key still means prototype assignment in an object literal
+    // (ECMAScript Annex B.3.1); only the computed form keeps it as an own property.
+    .replaceAll(/(?<!\\)"__proto__":/g, '["__proto__"]:')
+    .replaceAll(/(?<!\\)"([A-Za-z_$][\w$]*)":/g, "$1:")
 
   if (!continuationIndent) {
     return serialized

--- a/src/lib/shared/json.ts
+++ b/src/lib/shared/json.ts
@@ -27,6 +27,16 @@ export const checkIsJsonArray = (
   value: JsonValue | Schema.Json | undefined
 ): value is JsonValue[] => Array.isArray(value)
 
+export function serializeTsPropertyKey(key: string) {
+  // A quoted "__proto__" key still means prototype assignment in an object literal
+  // (ECMAScript Annex B.3.1); only the computed form keeps it as an own property.
+  if (key === "__proto__") {
+    return '["__proto__"]'
+  }
+
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? key : JSON.stringify(key)
+}
+
 export function serializeTsObjectLiteral(
   value: JsonValue,
   options: {
@@ -39,8 +49,8 @@ export function serializeTsObjectLiteral(
   // JSON.stringify output is always a real string boundary, so the lookbehind keeps the
   // rewrites from matching inside keys that contain escaped quotes.
   const serialized = JSON.stringify(value, null, indentation)
-    // A quoted "__proto__" key still means prototype assignment in an object literal
-    // (ECMAScript Annex B.3.1); only the computed form keeps it as an own property.
+    // Same Annex B.3.1 hazard as serializeTsPropertyKey: only the computed form keeps
+    // __proto__ as an own property.
     .replaceAll(/(?<!\\)"__proto__":/g, '["__proto__"]:')
     .replaceAll(/(?<!\\)"([A-Za-z_$][\w$]*)":/g, "$1:")
 

--- a/src/lib/workspace/tooling/__tests__/knip.test.ts
+++ b/src/lib/workspace/tooling/__tests__/knip.test.ts
@@ -18,4 +18,18 @@ describe("toKnipTsConfigContent", () => {
     expect(content).toContain("    binaries: {")
     expect(content).toContain('        severity: "error"')
   })
+
+  test("quote config and rule keys that are not valid identifiers", () => {
+    const content = toKnipTsConfigContent({
+      "lint-staged": {
+        entry: ["a.js"],
+      },
+      rules: {
+        "no-such/rule": "off",
+      },
+    })
+
+    expect(content).toContain('  "lint-staged": {')
+    expect(content).toContain('    "no-such/rule": "off",')
+  })
 })

--- a/src/lib/workspace/tooling/__tests__/oxfmt.test.ts
+++ b/src/lib/workspace/tooling/__tests__/oxfmt.test.ts
@@ -13,4 +13,10 @@ describe("toOxfmtTsConfigContent", () => {
     expect(content).toContain("    ...format.sortImports,")
     expect(content).toContain('    order: "desc"')
   })
+
+  test("quote top-level keys that are not valid identifiers", () => {
+    const content = toOxfmtTsConfigContent({ "experimental-option": true })
+
+    expect(content).toContain('  "experimental-option": true,')
+  })
 })

--- a/src/lib/workspace/tooling/knip.ts
+++ b/src/lib/workspace/tooling/knip.ts
@@ -1,18 +1,22 @@
 import type { JsonObject } from "type-fest"
-import { checkIsJsonObject, serializeTsObjectLiteral } from "#lib/shared/json.ts"
+import {
+  checkIsJsonObject,
+  serializeTsObjectLiteral,
+  serializeTsPropertyKey,
+} from "#lib/shared/json.ts"
 
 export function toKnipTsConfigContent(config: JsonObject = {}) {
   const configEntries = Object.entries(config).map(([key, value]) => {
     if (key === "rules" && checkIsJsonObject(value)) {
       const rulesEntries = Object.entries(value).map(
         ([ruleName, ruleValue]) =>
-          `    ${ruleName}: ${serializeTsObjectLiteral(ruleValue, { continuationIndent: "    ", indentation: "    " })},`
+          `    ${serializeTsPropertyKey(ruleName)}: ${serializeTsObjectLiteral(ruleValue, { continuationIndent: "    ", indentation: "    " })},`
       )
 
       return ["  rules: {", "    ...analyze.rules,", ...rulesEntries, "  },"].join("\n")
     }
 
-    return `  ${key}: ${serializeTsObjectLiteral(value)},`
+    return `  ${serializeTsPropertyKey(key)}: ${serializeTsObjectLiteral(value)},`
   })
 
   if (configEntries.length === 0) {

--- a/src/lib/workspace/tooling/oxfmt.ts
+++ b/src/lib/workspace/tooling/oxfmt.ts
@@ -1,5 +1,9 @@
 import type { JsonObject } from "type-fest"
-import { checkIsJsonObject, serializeTsObjectLiteral } from "#lib/shared/json.ts"
+import {
+  checkIsJsonObject,
+  serializeTsObjectLiteral,
+  serializeTsPropertyKey,
+} from "#lib/shared/json.ts"
 
 const NESTED_MERGE_KEYS = new Set(["sortImports", "sortPackageJson", "sortTailwindcss"])
 
@@ -31,7 +35,7 @@ export function toOxfmtTsConfigContent(config: JsonObject = {}) {
 
     const serialized = serializeTsObjectLiteral(value, { continuationIndent: "  " })
 
-    return `  ${key}: ${serialized},`
+    return `  ${serializeTsPropertyKey(key)}: ${serialized},`
   })
 
   if (configEntries.length === 0) {


### PR DESCRIPTION
Closes #385. Closes #387.

The property tests in #383 caught the key-unquoting regex in `serializeTsObjectLiteral` matching text it should not. A key containing a double quote serializes with an escaped quote, and the regex rewrote the bare `"A":` substring inside it — so migrating a knip or oxfmt config with such a key produced a `*.config.ts` with invalid syntax while Adamantite reported success. It also unquoted `__proto__`, turning the key into prototype assignment so it vanished from the evaluated config.

Both rewrites now use a `(?<!\\)` lookbehind: an unescaped `"` in `JSON.stringify` output is always a real string boundary, so escaped quotes inside keys can no longer be mistaken for key delimiters.

For `__proto__`, the fix the issue proposed (leave the key quoted) turns out to be insufficient: per ECMAScript Annex B.3.1, `"__proto__": value` in an object literal *also* sets the prototype. Only the computed form creates an own property, so the serializer now emits `["__proto__"]:`.

Tests: the two `it.fails` pins are flipped into regular assertions, the general round-trip property test drops its hazardous-key filter, and the tricky-key generator now produces quote-containing keys and `__proto__` (300/500 fast-check runs pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)

---

**Update:** review surfaced that the knip/oxfmt config writers interpolated top-level and rule keys as bare identifiers (#387), so a legal hyphenated knip key like `lint-staged` still produced invalid TypeScript. Keys are now emitted through a shared `serializeTsPropertyKey` helper (quote non-identifiers, computed form for `__proto__`), with a 300-run property test of the helper against the evaluation oracle plus wiring pins in both writer tests.
