### PR TITLE
Remove redundant pnpm workspace package declaration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,2 @@
-packages:
-  - "."
-
 allowBuilds:
   msgpackr-extract: false


### PR DESCRIPTION
Adamantite has one package, but `pnpm-workspace.yaml` explicitly includes the root package even though pnpm always includes it. This makes the workspace configuration look necessary for package discovery.

Remove the redundant `packages` field while keeping the `allowBuilds` decision for `msgpackr-extract`.

Verified with `pnpm run test`, `pnpm run check`, `pnpm run fix`, `pnpm run format`, and `pnpm run analyze`.

Created with GPT-5.6 Codex in the T3 Code harness.