### PR TITLE
Spec the agent-first doctor: findings and prompts replace migrations

### DIFF
--- a/docs/adr/0002-doctor-instructs-agents-mutate.md
+++ b/docs/adr/0002-doctor-instructs-agents-mutate.md
@@ -1,0 +1,48 @@
+# Doctor instructs; agents mutate
+
+Migrations and doctor's fix machinery encoded transformations between enumerated states
+and grew brittler with every legacy state discovered. We decided (2026-08-20) to make
+`adamantite doctor` assess-and-instruct only: the CLI deterministically detects broken
+state and emits findings — current state, goal criteria, verification — and agents or
+humans perform the mutations, with doctor's re-run as the convergence oracle. See
+[the implementation plan](../plans/agent-first-doctor.md) for the full design.
+
+The decisions:
+
+- Init keeps deterministic `create()` and its write paths; templating into empty space
+  is reliable and must not require an agent. Doctor and `update` never write files.
+- `doctor --fix` is removed (stubbed with a pointer error for one release). `update`
+  survives, scoped to dependency bumps, then runs doctor's assess-and-render pipeline.
+- All six migrations port their `check()` detection to findings; all `migrate()` code
+  and the snapshot/rollback machinery are deleted.
+- Detection becomes content-level with required-subset semantics (oxlint's inspection
+  model generalized): required shape must be present, user additions pass. Exact-match
+  comparison is rejected because it permanently flags legitimate customizations.
+- Findings are colocated with the detection code, and one combined prompt is emitted
+  per run. Two renderings (terminal view, markdown prompt) derive from the same
+  structs; only presentation may differ.
+- Creation findings embed exact canonical content; repair findings are criteria-first
+  with canonical content as reference, preserving user customizations.
+- In a TTY, doctor offers to spawn Claude Code or Codex headless (PATH-detected,
+  extensible table) with edit-level permissions, a printed command, and a dirty-tree
+  confirmation, then re-assesses once — no outer retry loop. Non-TTY gets the report
+  and exit code only. The prompt is also printable with best-effort OSC 52 clipboard
+  copy.
+- Harness invocation sits behind an injectable service so tests run a fake harness.
+- `AGENTS.md` and the shipped skill slim to "run `adamantite doctor` and follow its
+  instructions"; instructions exist only in doctor's output.
+
+## Consequences
+
+- Newly discovered legacy states cost a detection check and instruction text, not
+  transformation code, rollback handling, and their tests.
+- A version bump can leave a project flagged-but-not-fixed until an agent or human acts
+  on the prompt; `update`'s contract changes from "converges" to "converges or hands
+  you a prompt".
+- The oracle is only as strong as `assess`: any managed config without content-level
+  inspection weakens the verification step, so new managed surfaces must ship with
+  inspection (phase 2 covers zed, vscode, the GitHub workflow, and tsconfig).
+- Atomicity moves from `runMigration` snapshots to git hygiene; the prompt and the
+  spawn flow both surface the clean-tree requirement.
+- CI scripts calling `doctor --fix` break on the next minor; the stub error and a
+  changeset document the replacement.

--- a/docs/adr/0002-doctor-instructs-agents-mutate.md
+++ b/docs/adr/0002-doctor-instructs-agents-mutate.md
@@ -12,7 +12,8 @@ The decisions:
 - Init keeps deterministic `create()` and its write paths; templating into empty space
   is reliable and must not require an agent. Doctor and `update` never write files.
 - `doctor --fix` is removed (stubbed with a pointer error for one release). `update`
-  survives, scoped to dependency bumps, then runs doctor's assess-and-render pipeline.
+  survives, scoped to dependency bumps, then runs doctor's assess-and-render pipeline;
+  it keeps exiting 0 while findings remain, so doctor stays the only CI gate.
 - All six migrations port their `check()` detection to findings; all `migrate()` code
   and the snapshot/rollback machinery are deleted.
 - Detection becomes content-level with required-subset semantics (oxlint's inspection

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,4 @@
 # Architecture decision records
 
 - [ADR 0001: Keep unicorn/no-array-callback-reference in the core lint preset](0001-keep-no-array-callback-reference.md)
+- [ADR 0002: Doctor instructs; agents mutate](0002-doctor-instructs-agents-mutate.md)

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -80,15 +80,25 @@ hardcoded node version, stale Zed oxfmt settings). All `migrate()` code, `runMig
 and the snapshot/rollback machinery are deleted.
 
 Porting rule: each ported finding's goal criteria must cover the full end state its
-`migrate()` produced, not just the trigger its `check()` tested. The concrete case is
-`legacy-typecheck-script`: its `check()` reads one script key, but its `migrate()`
-wrote five files. It stays one finding (the states are coupled — that is why it was one
-migration), and its goals cover the script rename, the oxlint config (already verified
-by oxlint's own content-level assessment), the tsconfig `extends` including
-adamantite's preset, and the CI workflow referencing the `check` script. The last two
-need small new checks (roughly ten lines each) that land in phase 1 as early slivers of
-the phase 2 surfaces. Doctor must not exit 0 while a partially applied legacy migration
-remains.
+`migrate()` produced, not just the trigger its `check()` tested — and each goal carries
+over the conditions the `migrate()` applied it under. Conditions that produced warnings
+instead of writes become `notes`, not gated goals. No project shape may leave a finding
+open with no action that closes it.
+
+The concrete case is `legacy-typecheck-script`: its `check()` reads one script key, but
+its `migrate()` wrote up to five files. It stays one finding (the states are coupled —
+that is why it was one migration). Its goals cover the script rename and the oxlint
+config (already verified by oxlint's own content-level assessment) unconditionally. The
+tsconfig `extends` goal applies only outside a monorepo; in a monorepo it is dropped
+and the existing `MONOREPO_GUIDANCE` text becomes a note, mirroring the old
+`validate()` exemption. The CI workflow goal applies only when the workflow file
+already exists and the managed scripts are CI-compatible with a supported package
+manager — `migrate()` never created a workflow, and neither does this finding; when the
+conditions fail, the old warning text becomes a note. Both new checks (tsconfig
+`extends`, workflow `check`-script) are conditional and need the managed-script and
+package-manager context that `github.update` takes; they land in phase 1 as early
+slivers of the phase 2 surfaces. Doctor must not exit 0 while a partially applied
+legacy migration remains satisfiable.
 
 ### Prompt
 
@@ -135,9 +145,9 @@ the same fixture-driven tests.
 
 Placement: `src/lib/**` must not import `#terminal/*` (the `no-restricted-imports`
 override in `oxlint.config.ts`), so the markdown renderer — a pure struct-to-string
-function — lives in `src/lib/`, and the clack terminal renderer lives in the command
-layer (`src/terminal/`), matching the rule that lib returns data and commands render
-it.
+function — lives in `src/lib/`, and the clack terminal renderer lives in the terminal
+layer (`src/terminal/`, alongside `Prompter`), matching the rule that lib returns data
+and the command/terminal layers render it.
 
 ### Doctor command flow
 
@@ -163,9 +173,11 @@ today's into code without checking.
   running `adamantite doctor` / `adamantite update`), not full autonomy.
 - Print the exact command before spawning.
 - Warn and confirm when the working tree is dirty; do not hard-refuse.
-- Afterward, re-assess once and report converged or the surviving findings, with the
-  matching exit code. No outer retry loop: the agent already loops internally against
-  the oracle, and a second identical round doubles cost without a human look-in.
+- Afterward, re-assess once and report converged or the surviving findings. The
+  process exit code follows the invoking command's contract: doctor exits 1 while
+  findings survive; `update` keeps its own exit rule (below) even after a spawn. No
+  outer retry loop: the agent already loops internally against the oracle, and a
+  second identical round doubles cost without a human look-in.
 
 The invocation lives behind an injectable Effect service following the
 `DependencyInstaller` pattern (`src/lib/workspace/`): the service owns process spawning
@@ -186,9 +198,11 @@ findings instruct running `adamantite update`.
 
 Exit code: `update` keeps exiting 0 when the bumps succeed, even while findings
 remain — findings in its output are informational. It exits nonzero only when a bump
-itself fails. Doctor is the only CI gate; giving `update` doctor's exit contract would
-break existing CI jobs at exactly the common moment, since bumps are what create
-findings.
+itself fails. This rule wins in every path through `update`, including after a spawned
+harness run from its TTY menu: the shared pipeline provides assess, render, and menu,
+but the exit contract belongs to the invoking command. Doctor is the only CI gate;
+giving `update` doctor's exit contract would break existing CI jobs at exactly the
+common moment, since bumps are what create findings.
 
 ### init unchanged
 

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -1,0 +1,210 @@
+# Plan: agent-first doctor
+
+## Goal
+
+Turn `adamantite doctor` into an assess-and-instruct command. The CLI deterministically
+detects and describes broken state; agents (or humans) perform the mutations. Doctor's
+assessment is the oracle that defines convergence: every finding states the current
+state, the goal criteria, and the verification step "run `adamantite doctor`, expect
+exit 0". Delete the migration system and every write path that doctor and `update` own
+today.
+
+## Background
+
+The brittleness in doctor and `update` is concentrated in mutation code, not detection:
+
+- `src/lib/migrations/` is 765 lines of transformation code (plus snapshot/rollback
+  machinery in `runMigration`) that branches on config formats, monorepo-ness, workflow
+  existence, and package-manager support — and still bails with warnings on states it
+  cannot handle. Every newly discovered legacy state means more transformation code and
+  tests, forever.
+- Migrations encode transformations (state A to state B). Instructions encode the goal
+  state plus an oracle, so the set of legacy states no longer needs enumeration: the
+  agent bridges from whatever state exists, and doctor's re-assessment decides whether
+  it converged.
+- Doctor and `update` assess only the five tooling integrations (knip, oxfmt, oxlint,
+  sherif, tsgolint). The zed, vscode, GitHub-workflow, and tsconfig write paths are
+  init-only and never assessed — precisely because assessing them would have required
+  merge machinery. Instruction-based repair makes that coverage cheap (phase 2).
+- Drift detection today is existence-and-extension only for every config except oxlint,
+  which parses content and classifies `configured`/`patchable`/`manual`. An oracle that
+  cannot tell "fixed" from "file exists" would pass agent runs that did not converge, so
+  detection must become content-level.
+
+## Design
+
+### Findings replace actions
+
+Each integration's `assess` returns structured findings in place of today's action union
+(`create_config`/`update_config`/`manual_fix`/`run_migration`):
+
+```ts
+interface Finding {
+  readonly title: string;
+  /** What was detected and why it is a problem. */
+  readonly currentState: string;
+  /** End criteria — the same facts assess checks, as bullets. */
+  readonly goal: readonly string[];
+  /** Canonical file content, when applicable. */
+  readonly reference?: string;
+  /** Constraints: preserve user customizations, monorepo caveats, and similar. */
+  readonly notes?: readonly string[];
+}
+```
+
+`install_package` and `update_package` actions remain structured (update consumes them),
+but doctor renders them as findings whose instruction is to run `adamantite update`.
+Findings are colocated with the detection code that triggers them so criteria and
+instructions cannot drift; a renderer owns tone and format, integrations own substance.
+
+### Content-level oracle
+
+Generalize oxlint's `inspectRequiredOxlintConfig` model to every managed config:
+required-subset semantics, not exact match. Parse the config, assert the required
+options and shape are present, and let user additions pass. The goal bullets in each
+finding state the same facts the inspection checks. Exact-match comparison is rejected:
+it would permanently flag legitimate user customizations.
+
+### Legacy states port to findings
+
+All six migrations' `check()` detection logic ports over as finding-emitting assessments
+(legacy `knip.json`, legacy oxfmt JSON, legacy oxlint JSON, legacy typecheck script,
+hardcoded node version, stale Zed oxfmt settings). All `migrate()` code, `runMigration`,
+and the snapshot/rollback machinery are deleted.
+
+### Prompt
+
+One combined prompt per run. Findings are frequently coupled (a script rename touches
+the oxlint config touches the CI workflow), and a single prompt keeps the verification
+unambiguous. Template:
+
+```markdown
+# Adamantite doctor findings
+
+This project uses Adamantite <version> to manage linting/formatting/type tooling.
+`adamantite doctor` found N issue(s). Fix them so that `adamantite doctor` exits 0.
+Before editing, make sure the working tree is clean or the user has accepted the risk.
+
+## 1. <finding title>
+
+- **Current state:** <what was detected and why it is a problem>
+- **Goal:** <end criteria bullets>
+- **Reference:** <canonical content in a fenced block, when applicable>
+- **Notes:** <constraints>
+
+## Verify
+
+Run `adamantite doctor`. All findings above must be gone and it must exit 0.
+Do not suppress or work around checks; fix the underlying state.
+```
+
+Two non-negotiable lines: the git-clean warning (the copy-prompt path has no dirty-tree
+confirmation, so this is its only safety net) and the do-not-suppress line (an agent
+optimizing for "exit 0" will otherwise silence checks instead of fixing state).
+
+For creation findings (file missing), embed the exact canonical content from the
+existing builders (`toOxlintTsConfigContent` and friends, which init keeps) and instruct
+the agent not to improvise. For repair findings (file exists but fails criteria), the
+criteria are the contract and the canonical content is a known-good reference; the agent
+must preserve user customizations that still satisfy the criteria.
+
+### Two renderings, one source
+
+Findings render twice from the same structs: a human-styled terminal view (clack log
+blocks) and the markdown prompt used by copy-prompt and the spawn path. Only
+presentation may differ between the renderings, never substance; both are exercised by
+the same fixture-driven tests.
+
+### Doctor command flow
+
+1. Assess. If no findings, exit 0.
+2. Print the terminal rendering of every finding. Exit code is 1 while findings exist.
+3. If stdout is a TTY, offer a menu: fix with Claude Code, fix with Codex (each shown
+   only if its binary is detected on PATH, driven by a small extensible harness table),
+   or get the prompt. Non-TTY consumers (agents, CI, pipes) get the report and exit
+   code, no menu, no detection heuristics.
+4. "Get the prompt" prints the markdown prompt and attempts an OSC 52 clipboard copy
+   (write-and-forget escape sequence, no dependency, silent no-op where unsupported).
+5. `--fix` is removed. The flag remains parseable for one release and errors with a
+   pointer to the new model, then disappears.
+
+### Harness spawn
+
+Selecting a harness runs it headless (`claude -p` / `codex exec`) with the markdown
+prompt. Verify the exact flag names for both CLIs at implementation time; do not bake
+today's into code without checking.
+
+- Permissions: edit-level plus what the verification command needs (file edits and
+  running `adamantite doctor` / `adamantite update`), not full autonomy.
+- Print the exact command before spawning.
+- Warn and confirm when the working tree is dirty; do not hard-refuse.
+- Afterward, re-assess once and report converged or the surviving findings, with the
+  matching exit code. No outer retry loop: the agent already loops internally against
+  the oracle, and a second identical round doubles cost without a human look-in.
+
+The invocation lives behind an injectable Effect service (as with `Prompter` and
+`DependencyInstaller`) so tests substitute a fake harness that mutates fixture files.
+Integration tests pin the loop's failure modes: harness missing, nonzero exit, partial
+fix, full convergence. Real-harness runs stay manual.
+
+### update command
+
+`update` survives, scoped to dependency bumps (keeping the fallback sweep over known
+packages). After bumping it runs the same assess-and-render pipeline as doctor — a
+version bump is exactly what creates legacy states, so the findings and prompt appear at
+the moment they are needed — including the TTY menu. Its migration pass and "Doctor
+follow-up" lines are deleted. Doctor never installs packages; its outdated-package
+findings instruct running `adamantite update`.
+
+### init unchanged
+
+Init keeps deterministic `create()` and its editor/CI/tsconfig write paths. Templating
+into empty space is reliable and must not require an agent. The canonical content
+builders therefore survive and double as the prompt's reference content.
+
+### Documentation collapses to one source
+
+`AGENTS.md` guidance and `skills/adamantite/SKILL.md` slim down: the repair sections
+reduce to "run `adamantite doctor`; it prints findings with goal criteria and
+verification — follow them." The skill keeps only what doctor cannot say (init flags,
+daily-workflow scripts). Instructions exist in exactly one place — doctor's output — so
+stale copies become structurally impossible.
+
+## Steps
+
+1. Define the `Finding` type and rework `assess` signatures; port the six migration
+   `check()`s into finding-emitting assessments; delete `src/lib/migrations/` and its
+   tests.
+2. Build content-level inspection for knip and oxfmt configs on the oxlint model;
+   express every finding's goal bullets from the same checks.
+3. Build the two renderers (terminal view, markdown prompt) from shared finding structs,
+   with snapshot tests.
+4. Rework `doctor.ts`: assess, render, exit codes, `--fix` stub error. Delete the fix
+   machinery and its tests.
+5. Add the TTY menu, harness table with PATH detection, OSC 52 copy.
+6. Add the harness-runner service, spawn flow (permission flags, command echo,
+   dirty-tree confirm), post-run re-assessment, and fake-harness integration tests.
+7. Rework `update.ts`: bumps plus the shared assess-and-render pipeline; delete its
+   migration pass and tests.
+8. Slim `writeAgentsGuidance` and `SKILL.md`; update README and `docs/architecture.md`.
+9. Minor changeset describing the breaking `doctor --fix` removal and the new model.
+
+## Phase 2 (named, not specified here)
+
+Extend assessment and findings to the init-only surfaces: zed, vscode, GitHub workflow,
+tsconfig. Instruction-based repair makes this coverage cheap — detection plus
+instruction text, no merge machinery. Requires content-level checks to be meaningful
+(editor settings files always exist once the editor is used). Spec separately.
+
+## Out of scope
+
+- Per-finding selection (one prompt covering a chosen subset).
+- An outer retry loop around harness spawns.
+- Harnesses beyond Claude Code and Codex (the table makes additions a row, not a
+  feature).
+- A `--json` output mode.
+- Pruning old legacy-state detections; that happens on its own schedule.
+
+## Completion
+
+Delete this file when the work is complete.

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -43,18 +43,18 @@ Each integration's `assess` returns structured findings in place of today's acti
 ```ts
 interface Finding {
   /** Stable machine-readable key, e.g. "legacy-knip-json". */
-  readonly id: string;
+  readonly id: string
   /** Source integration, for grouping and re-assessment diffs. */
-  readonly integration: string;
-  readonly title: string;
+  readonly integration: string
+  readonly title: string
   /** What was detected and why it is a problem. */
-  readonly currentState: string;
+  readonly currentState: string
   /** End criteria — the same facts assess checks, as bullets. */
-  readonly goal: readonly string[];
+  readonly goal: readonly string[]
   /** Canonical file content, when applicable. */
-  readonly reference?: string;
+  readonly reference?: string
   /** Constraints: preserve user customizations, monorepo caveats, and similar. */
-  readonly notes?: readonly string[];
+  readonly notes?: readonly string[]
 }
 ```
 

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -24,8 +24,10 @@ The brittleness in doctor and `update` is concentrated in mutation code, not det
   it converged.
 - Doctor and `update` assess only the five tooling integrations (knip, oxfmt, oxlint,
   sherif, tsgolint). The zed, vscode, GitHub-workflow, and tsconfig write paths are
-  init-only and never assessed — precisely because assessing them would have required
-  merge machinery. Instruction-based repair makes that coverage cheap (phase 2).
+  init-only and not assessed for drift — precisely because assessing them would have
+  required merge machinery. (Two migration checks read parts of those surfaces, but
+  nothing verifies their content.) Instruction-based repair makes that coverage cheap
+  (phase 2).
 - Drift detection today is existence-and-extension only for every config except oxlint,
   which parses content and classifies `configured`/`patchable`/`manual`. An oracle that
   cannot tell "fixed" from "file exists" would pass agent runs that did not converge, so
@@ -40,6 +42,10 @@ Each integration's `assess` returns structured findings in place of today's acti
 
 ```ts
 interface Finding {
+  /** Stable machine-readable key, e.g. "legacy-knip-json". */
+  readonly id: string;
+  /** Source integration, for grouping and re-assessment diffs. */
+  readonly integration: string;
   readonly title: string;
   /** What was detected and why it is a problem. */
   readonly currentState: string;
@@ -56,6 +62,7 @@ interface Finding {
 but doctor renders them as findings whose instruction is to run `adamantite update`.
 Findings are colocated with the detection code that triggers them so criteria and
 instructions cannot drift; a renderer owns tone and format, integrations own substance.
+Re-assessment diffs, tests, and fixtures key on `id`, never on prose fields.
 
 ### Content-level oracle
 
@@ -71,6 +78,17 @@ All six migrations' `check()` detection logic ports over as finding-emitting ass
 (legacy `knip.json`, legacy oxfmt JSON, legacy oxlint JSON, legacy typecheck script,
 hardcoded node version, stale Zed oxfmt settings). All `migrate()` code, `runMigration`,
 and the snapshot/rollback machinery are deleted.
+
+Porting rule: each ported finding's goal criteria must cover the full end state its
+`migrate()` produced, not just the trigger its `check()` tested. The concrete case is
+`legacy-typecheck-script`: its `check()` reads one script key, but its `migrate()`
+wrote five files. It stays one finding (the states are coupled — that is why it was one
+migration), and its goals cover the script rename, the oxlint config (already verified
+by oxlint's own content-level assessment), the tsconfig `extends` including
+adamantite's preset, and the CI workflow referencing the `check` script. The last two
+need small new checks (roughly ten lines each) that land in phase 1 as early slivers of
+the phase 2 surfaces. Doctor must not exit 0 while a partially applied legacy migration
+remains.
 
 ### Prompt
 
@@ -115,14 +133,21 @@ blocks) and the markdown prompt used by copy-prompt and the spawn path. Only
 presentation may differ between the renderings, never substance; both are exercised by
 the same fixture-driven tests.
 
+Placement: `src/lib/**` must not import `#terminal/*` (the `no-restricted-imports`
+override in `oxlint.config.ts`), so the markdown renderer — a pure struct-to-string
+function — lives in `src/lib/`, and the clack terminal renderer lives in the command
+layer (`src/terminal/`), matching the rule that lib returns data and commands render
+it.
+
 ### Doctor command flow
 
 1. Assess. If no findings, exit 0.
 2. Print the terminal rendering of every finding. Exit code is 1 while findings exist.
-3. If stdout is a TTY, offer a menu: fix with Claude Code, fix with Codex (each shown
-   only if its binary is detected on PATH, driven by a small extensible harness table),
-   or get the prompt. Non-TTY consumers (agents, CI, pipes) get the report and exit
-   code, no menu, no detection heuristics.
+3. If stdout and stdin are both TTYs (the menu prints to one and reads from the
+   other), offer a menu: fix with Claude Code, fix with Codex (each shown only if its
+   binary is detected on PATH, driven by a small extensible harness table), or get the
+   prompt. Other consumers (agents, CI, pipes, redirected stdin) get the report and
+   exit code, no menu, no detection heuristics.
 4. "Get the prompt" prints the markdown prompt and attempts an OSC 52 clipboard copy
    (write-and-forget escape sequence, no dependency, silent no-op where unsupported).
 5. `--fix` is removed. The flag remains parseable for one release and errors with a
@@ -142,8 +167,11 @@ today's into code without checking.
   matching exit code. No outer retry loop: the agent already loops internally against
   the oracle, and a second identical round doubles cost without a human look-in.
 
-The invocation lives behind an injectable Effect service (as with `Prompter` and
-`DependencyInstaller`) so tests substitute a fake harness that mutates fixture files.
+The invocation lives behind an injectable Effect service following the
+`DependencyInstaller` pattern (`src/lib/workspace/`): the service owns process spawning
+and PATH detection only, no terminal I/O. The command echo, dirty-tree confirmation,
+and spinner stay in `doctor.ts` via `Prompter`, keeping the lib/terminal lint boundary
+intact. Tests substitute a fake harness that mutates fixture files.
 Integration tests pin the loop's failure modes: harness missing, nonzero exit, partial
 fix, full convergence. Real-harness runs stay manual.
 
@@ -155,6 +183,12 @@ version bump is exactly what creates legacy states, so the findings and prompt a
 the moment they are needed — including the TTY menu. Its migration pass and "Doctor
 follow-up" lines are deleted. Doctor never installs packages; its outdated-package
 findings instruct running `adamantite update`.
+
+Exit code: `update` keeps exiting 0 when the bumps succeed, even while findings
+remain — findings in its output are informational. It exits nonzero only when a bump
+itself fails. Doctor is the only CI gate; giving `update` doctor's exit contract would
+break existing CI jobs at exactly the common moment, since bumps are what create
+findings.
 
 ### init unchanged
 
@@ -173,19 +207,21 @@ stale copies become structurally impossible.
 ## Steps
 
 1. Define the `Finding` type and rework `assess` signatures; port the six migration
-   `check()`s into finding-emitting assessments; delete `src/lib/migrations/` and its
-   tests.
-2. Build content-level inspection for knip and oxfmt configs on the oxlint model;
-   express every finding's goal bullets from the same checks.
-3. Build the two renderers (terminal view, markdown prompt) from shared finding structs,
-   with snapshot tests.
+   `check()`s into finding-emitting assessments under the porting rule (goals cover
+   each `migrate()`'s full end state); delete `src/lib/migrations/` and its tests.
+2. Build content-level inspection for knip and oxfmt configs on the oxlint model, plus
+   the tsconfig-`extends` and workflow-script checks the legacy-typecheck finding
+   needs; express every finding's goal bullets from the same checks.
+3. Build the two renderers from shared finding structs — markdown prompt in
+   `src/lib/`, terminal view in `src/terminal/` — with snapshot tests.
 4. Rework `doctor.ts`: assess, render, exit codes, `--fix` stub error. Delete the fix
    machinery and its tests.
 5. Add the TTY menu, harness table with PATH detection, OSC 52 copy.
-6. Add the harness-runner service, spawn flow (permission flags, command echo,
-   dirty-tree confirm), post-run re-assessment, and fake-harness integration tests.
-7. Rework `update.ts`: bumps plus the shared assess-and-render pipeline; delete its
-   migration pass and tests.
+6. Add the harness-runner service (`src/lib/workspace/`, `DependencyInstaller`
+   pattern), the spawn flow in `doctor.ts` (permission flags, command echo, dirty-tree
+   confirm), post-run re-assessment, and fake-harness integration tests.
+7. Rework `update.ts`: bumps plus the shared assess-and-render pipeline, keeping exit 0
+   while findings remain; delete its migration pass and tests.
 8. Slim `writeAgentsGuidance` and `SKILL.md`; update README and `docs/architecture.md`.
 9. Minor changeset describing the breaking `doctor --fix` removal and the new model.
 

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -99,9 +99,12 @@ used:
 
 - The legacy-typecheck finding keeps the script rename as its goal; the oxlint config
   is already verified by oxlint's own content-level assessment.
-- A tsconfig assessment checks that `extends` includes adamantite's preset, applicable
-  only outside a monorepo; in a monorepo the existing `MONOREPO_GUIDANCE` text is
-  surfaced as a warning instead, mirroring the old `validate()` exemption.
+- A tsconfig assessment checks that `tsconfig.json` exists and its `extends` includes
+  adamantite's preset, applicable only outside a monorepo — a missing file is a
+  finding, not not-applicable, mirroring the old `migrate()`'s create-vs-update branch
+  and its `validate()` failing on absence. In a monorepo the existing
+  `MONOREPO_GUIDANCE` text is surfaced as a warning instead, mirroring the old
+  `validate()` exemption.
 - A workflow assessment checks that an existing `.github/workflows/adamantite.yml`
   references the `check` script, applicable only when the managed scripts are
   CI-compatible with a supported package manager — `migrate()` never created a

--- a/docs/plans/agent-first-doctor.md
+++ b/docs/plans/agent-first-doctor.md
@@ -79,26 +79,38 @@ All six migrations' `check()` detection logic ports over as finding-emitting ass
 hardcoded node version, stale Zed oxfmt settings). All `migrate()` code, `runMigration`,
 and the snapshot/rollback machinery are deleted.
 
-Porting rule: each ported finding's goal criteria must cover the full end state its
-`migrate()` produced, not just the trigger its `check()` tested — and each goal carries
-over the conditions the `migrate()` applied it under. Conditions that produced warnings
-instead of writes become `notes`, not gated goals. No project shape may leave a finding
-open with no action that closes it.
+Porting rule: a ported finding's detection must be end-state detection — the finding
+fires while any of its goal criteria is unmet under its conditions, not only while the
+original `check()` trigger matches. Each goal carries over the conditions the
+`migrate()` applied it under, and conditions that produced warnings instead of writes
+become `notes`, not gated goals. Two invariants follow: no project shape may leave a
+finding open with no action that closes it, and satisfying a strict subset of the goals
+must not make doctor exit 0. Five of the six migrations already satisfy this — their
+`check()` detects the end state directly (a legacy file exists, a hardcoded version
+remains), so trigger and goal coincide.
 
-The concrete case is `legacy-typecheck-script`: its `check()` reads one script key, but
-its `migrate()` wrote up to five files. It stays one finding (the states are coupled —
-that is why it was one migration). Its goals cover the script rename and the oxlint
-config (already verified by oxlint's own content-level assessment) unconditionally. The
-tsconfig `extends` goal applies only outside a monorepo; in a monorepo it is dropped
-and the existing `MONOREPO_GUIDANCE` text becomes a note, mirroring the old
-`validate()` exemption. The CI workflow goal applies only when the workflow file
-already exists and the managed scripts are CI-compatible with a supported package
-manager — `migrate()` never created a workflow, and neither does this finding; when the
-conditions fail, the old warning text becomes a note. Both new checks (tsconfig
-`extends`, workflow `check`-script) are conditional and need the managed-script and
-package-manager context that `github.update` takes; they land in phase 1 as early
-slivers of the phase 2 surfaces. Doctor must not exit 0 while a partially applied
-legacy migration remains satisfiable.
+The exception is `legacy-typecheck-script`: its `check()` reads one script key, but its
+`migrate()` wrote up to five files. Widening that finding's trigger to all its goals
+would misfire — once the script is renamed, "half-migrated" is indistinguishable from
+"never had the legacy script", and projects that were never in the legacy state would
+be flagged with a legacy finding. Instead, the coupled surfaces become standalone
+phase 1 assessments with their own findings and the same conditions the `migrate()`
+used:
+
+- The legacy-typecheck finding keeps the script rename as its goal; the oxlint config
+  is already verified by oxlint's own content-level assessment.
+- A tsconfig assessment checks that `extends` includes adamantite's preset, applicable
+  only outside a monorepo; in a monorepo the existing `MONOREPO_GUIDANCE` text is
+  surfaced as a warning instead, mirroring the old `validate()` exemption.
+- A workflow assessment checks that an existing `.github/workflows/adamantite.yml`
+  references the `check` script, applicable only when the managed scripts are
+  CI-compatible with a supported package manager — `migrate()` never created a
+  workflow, and neither does this assessment. It needs the managed-script and
+  package-manager context that `github.update` takes.
+
+A partially applied fix then keeps doctor red through the standalone findings, and the
+combined prompt (below) still presents the coupled findings together whenever they
+co-occur. The two assessments are early slivers of the phase 2 surfaces.
 
 ### Prompt
 
@@ -221,11 +233,12 @@ stale copies become structurally impossible.
 ## Steps
 
 1. Define the `Finding` type and rework `assess` signatures; port the six migration
-   `check()`s into finding-emitting assessments under the porting rule (goals cover
-   each `migrate()`'s full end state); delete `src/lib/migrations/` and its tests.
+   `check()`s into finding-emitting assessments under the porting rule (end-state
+   detection covering each `migrate()`'s conditions); delete `src/lib/migrations/` and
+   its tests.
 2. Build content-level inspection for knip and oxfmt configs on the oxlint model, plus
-   the tsconfig-`extends` and workflow-script checks the legacy-typecheck finding
-   needs; express every finding's goal bullets from the same checks.
+   the standalone tsconfig-`extends` and workflow-script assessments that back the
+   legacy-typecheck porting; express every finding's goal bullets from the same checks.
 3. Build the two renderers from shared finding structs — markdown prompt in
    `src/lib/`, terminal view in `src/terminal/` — with snapshot tests.
 4. Rework `doctor.ts`: assess, render, exit codes, `--fix` stub error. Delete the fix


### PR DESCRIPTION
Doctor's migrations and fix machinery encode transformations between enumerated legacy states, and every newly discovered state means more branchy mutation code, rollback handling, and tests — 765 lines of migrations guarded by ~3,100 test lines, and it still bails on states it can't handle.

This spec flips the model: the CLI deterministically detects and describes; agents (or humans) mutate. Doctor emits findings — current state, goal criteria, verification — as one combined prompt, and its own re-run is the convergence oracle. In a TTY it can spawn Claude Code or Codex headless to apply the fixes and then re-assess; otherwise it prints the prompt (with best-effort clipboard copy). `--fix` goes away, `update` keeps dependency bumps and reuses doctor's pipeline, and init keeps its deterministic `create()` paths.

Docs only, no behavior change:

- `docs/plans/agent-first-doctor.md` — full design and implementation steps
- `docs/adr/0002-doctor-instructs-agents-mutate.md` — decision record and consequences

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Fable 5